### PR TITLE
[INLONG-606][website] Delete redundant description in architecture.html of zh-cn

### DIFF
--- a/docs/zh-cn/architecture.md
+++ b/docs/zh-cn/architecture.md
@@ -14,7 +14,7 @@ title: 架构介绍 - Apache TubeMQ
 
 - **Client**： 负责数据生产和消费的Client部分，该部分我们以Lib形式对外提供，大家用得最多的是消费端，相比之前，消费端现支持Push、Pull两种数据拉取模式，数据消费行为支持顺序和过滤消费两种。对于Pull消费模式，支持业务通过客户端重置精确offset以支持业务exactly-once消费，同时，消费端新推出跨集群切换免重启的BidConsumer客户端；
 
-- **Zookeeper**： 负责offset存储的zk部分，该部分功能已弱化到仅做offset的持久化存储，考虑到接下来的多节点副本功能该模块暂时保留。- **Zookeeper：** Responsible for the zk part of the offset storage. This part of the function has been weakened to only the persistent storage of the offset. Considering the next multi-node copy function, this module is temporarily reserved;
+- **Zookeeper**： 负责offset存储的zk部分，该部分功能已弱化到仅做offset的持久化存储，考虑到接下来的多节点副本功能该模块暂时保留。
 
 
 ## TubeMQ的系统特点


### PR DESCRIPTION
A pure type hotfix.