### PR TITLE
[INLONG-1458][DataProxy] The http port in agent readme should be 8008 to be consistent with the code

### DIFF
--- a/docs/en-us/modules/agent/quick_start.md
+++ b/docs/en-us/modules/agent/quick_start.md
@@ -45,7 +45,7 @@ agent.http.port=Available ports
 
 #### 3.2 Execute the following command
 ```bash
-    curl --location --request POST 'http://localhost:8129/config/job' \
+    curl --location --request POST 'http://localhost:8008/config/job' \
     --header 'Content-Type: application/json' \
     --data '{
     "job": {

--- a/docs/zh-cn/modules/agent/quick_start.md
+++ b/docs/zh-cn/modules/agent/quick_start.md
@@ -42,7 +42,7 @@ agent.http.port=可用端口
 
 #### 3.2 执行如下命令：
 ```bash
-curl --location --request POST 'http://localhost:8018/config/job' \
+curl --location --request POST 'http://localhost:8008/config/job' \
 --header 'Content-Type: application/json' \
 --data '{
 "job": {


### PR DESCRIPTION
Fixes #<1458>

### Motivation

The http port in agent readme should be 8008 to be consistent with the code

### Modifications

*Describe the modifications you've done.*

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

### Documentation

  - Does this pull request introduce a new feature? (no)
