### PR TITLE
[INLONG-1459] proxy address configuration is redundant for inlong-agent

### DIFF
--- a/docs/en-us/modules/agent/quick_start.md
+++ b/docs/en-us/modules/agent/quick_start.md
@@ -26,7 +26,7 @@ sh agent.sh start
 
 ## 3、Add job configuration in real time
 
-#### 3.1 agent.propertities Modify the following two places
+#### 3.1 agent.properties Modify the following two places
 ```ini
 # whether enable http service
 agent.http.enable=true

--- a/docs/en-us/modules/dataproxy/quick_start.md
+++ b/docs/en-us/modules/dataproxy/quick_start.md
@@ -1,7 +1,9 @@
 ## Deploy DataProxy
+
 All deploying files at `inlong-dataproxy` directory.
 
 ### config TubeMQ master
+
 `tubemq_master_list` is the rpc address of TubeMQ Master.
 ```
 $ sed -i 's/TUBE_LIST/tubemq_master_list/g' conf/flume.conf
@@ -10,18 +12,21 @@ $ sed -i 's/TUBE_LIST/tubemq_master_list/g' conf/flume.conf
 notice that conf/flume.conf FLUME_HOME is proxy the directory for proxy inner data
 
 ### Environmental preparation
+
 ```
 sh prepare_env.sh
 ```
 
 ### config manager web url
-配置文件`conf/common.properties`:
+
+configuration file: `conf/common.properties`:
 ```
 # manager web 
 manager_hosts=ip:port 
 ```
 
 ## run
+
 ```
 sh bin/start.sh
 ```
@@ -32,4 +37,19 @@ sh bin/start.sh
 telnet 127.0.0.1 46801
 ```
 
+## Add DataProxy configuration to InLong-Manager
+
+After installing the DataProxy, you need to insert the IP and port of the DataProxy service is located into the backend database of InLong-Manager.
+
+For the background database address of InLong-Manager, please refer to the deployment document of the InLong-Manager module.
+
+The insert SQL statement is:
+
+```sql
+-- name is the name of the DataProxy, which can be customized
+-- address is the IP of the DataProxy service is located
+-- port is the port of the DataProxy service, default is 46801
+insert into data_proxy_cluster (name, address, port, status, is_deleted, create_time, modify_time)
+values ("data_proxy_name", "data_proxy_ip", 46801, 0, 0, now(), now());
+```
 

--- a/docs/zh-cn/modules/agent/quick_start.md
+++ b/docs/zh-cn/modules/agent/quick_start.md
@@ -16,6 +16,7 @@ agent.manager.vip.http.port=manager web port
 ```
 
 ## 2、运行
+
 解压后如下命令运行
 ```bash
 sh agent.sh start
@@ -23,7 +24,8 @@ sh agent.sh start
 
 ### 3 实时添加job配置
 
-#### 3.1 agent.propertities 修改下面两处
+#### 3.1 agent.properties 修改下面两处
+
 ```ini
 # whether enable http service
 agent.http.enable=true
@@ -32,6 +34,7 @@ agent.http.port=可用端口
 ```
 
 #### 3.2 执行如下命令：
+
 ```bash
 curl --location --request POST 'http://localhost:8008/config/job' \
 --header 'Content-Type: application/json' \

--- a/docs/zh-cn/modules/dataproxy/quick_start.md
+++ b/docs/zh-cn/modules/dataproxy/quick_start.md
@@ -1,7 +1,9 @@
 ## 部署 DataProxy
-所有安装文件在`inlong-dataproxy`目录。
+
+所有的安装文件都在 `inlong-dataproxy` 目录下。
 
 ### 配置tube地址和端口号
+
 `tubemq_master_list`是TubeMQ master rpc地址，多个逗号分隔。
 ```
 $ sed -i 's/TUBE_LIST/tubemq_master_list/g' conf/flume.conf
@@ -10,25 +12,44 @@ $ sed -i 's/TUBE_LIST/tubemq_master_list/g' conf/flume.conf
 注意conf/flume.conf中FLUME_HOME为proxy的中间数据文件存放地址
 
 ### 环境准备
+
 ```
 sh prepare_env.sh
 ```
 
 ### 配置manager地址
-configuration file `conf/common.properties`:
+
+配置文件：`conf/common.properties`:
 ```
 # manager web url 
 manager_hosts=ip:port 
 ```
 
 ## 启动
+
 ```
 sh bin/start.sh
 ```
 
 ## 检查启动状态
+
 ```
 telnet 127.0.0.1 46801
 ```
 
+## 将 DataProxy 配置添加到 InLong-Manager
+
+安装完 DataProxy 后，需要将 DataProxy 所在主机的 IP 插入到 InLong-Manager 的后台数据库中。
+
+InLong-Manager 的后台数据库地址，请参考 InLong-Manager 模块的部署文档。
+
+插入 SQL 语句为：
+
+```sql
+-- name 为 DataProxy 的名称，可自定义
+-- address 为 DataProxy 服务所在主机的 IP
+-- port 为 DataProxy 服务所在的端口号，默认是 46801
+insert into data_proxy_cluster (name, address, port, status, is_deleted, create_time, modify_time)
+values ("data_proxy_name", "data_proxy_ip", 46801, 0, 0, now(), now());
+```
 


### PR DESCRIPTION
Fixes https://github.com/apache/incubator-inlong/issues/1459

### Modifications

InLong-Agent get data proxy ip list from InLong-Manager.

### Verifying this change

- [x] Make sure that the change passes the CI checks.


### Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)
