### PR TITLE
[INLONG-1625] fix the Contribution Guide errors

### DIFF
--- a/docs/en-us/development/how-to-contribute.md
+++ b/docs/en-us/development/how-to-contribute.md
@@ -17,7 +17,7 @@ We use a review-then-commit workflow in InLong for all contributions.
 
 1. **Code:** The you-know-what part.
 2. **Review:** Submit a pull request with your contribution to our [GitHub Repo](https://github.com/apache/incubator-inlong). Work with a committer to review and iterate on the code, if needed.
-3. **Commit:** Once at least 1 InLong committer has approved the pull request, a InLong committer will merge it into the master branch (and potentially backport to stable branches in case of bug fixes).
+3. **Commit:** Once at least 2 InLong committer has approved the pull request, a InLong committer will merge it into the master branch (and potentially backport to stable branches in case of bug fixes).
 
 We look forward to working with you!
 
@@ -42,15 +42,15 @@ For moderate or large contributions, you should not start coding or writing a de
 
 To avoid potential frustration during the code review cycle, we encourage you to clearly scope and design non-trivial contributions with the InLong community before you start coding.
 
-We are using "InLong Improvement Proposals" for managing major changes to InLong. The list of all proposals is maintained in the InLong wiki at [this page](https://cwiki.apache.org/confluence/display/INLONG/INLONG+Improvement+Proposals).
+We are using "InLong Improvement Proposals" for managing major changes to InLong. The list of all proposals is maintained in the InLong wiki at [this page](https://github.com/apache/incubator-inlong/wiki).
 
 ## Commit (committers only)
 
 Once the code has been peer reviewed by a committer, the next step is for the committer to merge it into the Github repo.
 
-Pull requests should not be merged before the review has approved from at least 1 committer.
+Pull requests should not be merged before the review has approved from at least 2 committer.
 
-For more about merging pull request, please refer to [this page](https://cwiki.apache.org/confluence/display/INLONG/Merging+Pull+Requests)
+For more about merging pull request, please refer to [this page](https://github.com/apache/incubator-inlong/pulls)
 
 ## Website Contributor List
 We are very pleased to announce some contributors here. They have made a lot of contributions in the translation of InLong. Thanks again to the following participants.


### PR DESCRIPTION
Fixes #https://github.com/apache/incubator-inlong/issues/1625

### Motivation

*Explain here the context, and why you're making that change. What is the problem you're trying to solve.*

### Modifications

*Describe the modifications you've done.*

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
