### PR TITLE
[INLONG-1652][Dataproxy] there is an unavailable link for the quick start of dataproxy-sdk

### DIFF
--- a/docs/en-us/modules/dataproxy-sdk/quick_start.md
+++ b/docs/en-us/modules/dataproxy-sdk/quick_start.md
@@ -1,6 +1,6 @@
 # how to use
 
-add dependency in pom and use the api in architecture.md
+add dependency in pom and use the api in [architecture](modules/dataproxy-sdk/architecture.md)
 
     <dependency>
             <groupId>org.apache.inlong</groupId>

--- a/docs/en-us/modules/dataproxy-sdk/quick_start.md
+++ b/docs/en-us/modules/dataproxy-sdk/quick_start.md
@@ -1,6 +1,6 @@
 # how to use
 
-add dependency in pom and use the api in [architecture](modules/dataproxy-sdk/architecture.md)
+add dependency in pom and use the api in [architecture](architecture.md)
 
     <dependency>
             <groupId>org.apache.inlong</groupId>

--- a/docs/zh-cn/modules/dataproxy-sdk/quick_start.md
+++ b/docs/zh-cn/modules/dataproxy-sdk/quick_start.md
@@ -1,6 +1,6 @@
 # 使用
 
-编写java程序时，增加pom配置如下：
+编写java程序时，增加pom配置如下并使用[architecture](modules/dataproxy-sdk/architecture.md)中定义的api进行发送：
 
     <dependency>
             <groupId>org.apache.inlong</groupId>

--- a/docs/zh-cn/modules/dataproxy-sdk/quick_start.md
+++ b/docs/zh-cn/modules/dataproxy-sdk/quick_start.md
@@ -1,6 +1,6 @@
 # 使用
 
-编写java程序时，增加pom配置如下并使用[architecture](modules/dataproxy-sdk/architecture.md)中定义的api进行发送：
+编写java程序时，增加pom配置如下并使用[architecture](architecture.md)中定义的api进行发送：
 
     <dependency>
             <groupId>org.apache.inlong</groupId>


### PR DESCRIPTION

Fixes https://github.com/apache/incubator-inlong/issues/1652

### Motivation

there is an unavailable link for the quick start of dataproxy-sdk

### Modifications

make link available 

### Verifying this change

- [ ] Make sure that the change passes the CI checks.


### Documentation

  - Does this pull request introduce a new feature? (no)
