### PR TITLE
[INLONG-1634] Migrate download documentation

### DIFF
--- a/download/main.md
+++ b/download/main.md
@@ -1,0 +1,59 @@
+---
+title: Download
+---
+
+## Download links
+  Use the links below to download the Apache InLong Releases, the latest release is 0.10.0.
+
+## 0.10.0 release
+- Released: Sept 11, 2021
+- [Release Notes](release-0.10.0.md)
+- Source: [inlong-0.10.0-incubating-src.tar.gz](http://www.apache.org/dyn/closer.lua/incubator/inlong/0.10.0-incubating/apache-inlong-0.10.0-incubating-src.tar.gz)              [[ASC](https://downloads.apache.org/incubator/inlong/0.10.0-incubating/apache-inlong-0.10.0-incubating-src.tar.gz.asc)]        [[SHA512](https://downloads.apache.org/incubator/inlong/0.10.0-incubating/apache-inlong-0.10.0-incubating-src.tar.gz.sha512)]
+
+## Release Integrity
+   You must [verify](https://www.apache.org/info/verification.html) the integrity of the downloaded files. We provide OpenPGP signatures for every release file. This signature should be matched against the [KEYS](https://downloads.apache.org/incubator/inlong/KEYS) file which contains the OpenPGP keys of InLong's Release Managers. We also provide <code>SHA-512</code> checksums for every release file. After you download the file, you should calculate a checksum for your download, and make sure it is the same as ours.
+
+
+## 0.9.0 release
+ - Released: July 11, 2021
+ - [Release Notes](release-0.9.0.md)
+ - Source: [inlong-0.9.0-incubating-src.tar.gz](https://archive.apache.org/dist/incubator/inlong/0.9.0-incubating/apache-inlong-0.9.0-incubating-src.tar.gz)              [[ASC](https://archive.apache.org/dist/incubator/inlong/0.9.0-incubating/apache-inlong-0.9.0-incubating-src.tar.gz.asc)]        [[SHA512](https://archive.apache.org/dist/incubator/inlong/0.9.0-incubating/apache-inlong-0.9.0-incubating-src.tar.gz.sha512)]
+
+
+## 0.8.0 release
+
+ - Released: March 4th, 2021
+ - [Release Notes](release-0.8.0.md)
+ - Source: [tubemq-0.8.0-incubating-src.tar.gz](https://archive.apache.org/dist/incubator/tubemq/0.8.0-incubating/apache-tubemq-0.8.0-incubating-src.tar.gz)              [[ASC](https://archive.apache.org/dist/incubator/tubemq/0.8.0-incubating/apache-tubemq-0.8.0-incubating-src.tar.gz.asc)]        [[SHA512](https://archive.apache.org/dist/incubator/tubemq/0.8.0-incubating/apache-tubemq-0.8.0-incubating-src.tar.gz.sha512)]
+ - Client: [tubemq-client-0.8.0-incubating-bin.tar.gz](https://archive.apache.org/dist/incubator/tubemq/0.8.0-incubating/apache-tubemq-client-0.8.0-incubating-bin.tar.gz)       [[ASC](https://archive.apache.org/dist/incubator/tubemq/0.8.0-incubating/apache-tubemq-client-0.8.0-incubating-bin.tar.gz.asc)] [[SHA512](https://archive.apache.org/dist/incubator/tubemq/0.8.0-incubating/apache-tubemq-client-0.8.0-incubating-bin.tar.gz.sha512)]
+ - Server: [tubemq-server-0.8.0-incubating-bin.tar.gz](https://archive.apache.org/dist/incubator/tubemq/0.8.0-incubating/apache-tubemq-server-0.8.0-incubating-bin.tar.gz)       [[ASC](https://archive.apache.org/dist/incubator/tubemq/0.8.0-incubating/apache-tubemq-server-0.8.0-incubating-bin.tar.gz.asc)] [[SHA512](https://archive.apache.org/dist/incubator/tubemq/0.8.0-incubating/apache-tubemq-server-0.8.0-incubating-bin.tar.gz.sha512)]
+
+## 0.7.0 release
+
+ - Released: December 4th, 2020
+ - [Release Notes](release-0.7.0.md)
+ - Source: [tubemq-0.7.0-incubating-src.tar.gz](https://archive.apache.org/dist/incubator/tubemq/0.7.0-incubating/apache-tubemq-0.7.0-incubating-src.tar.gz)              [[ASC](https://archive.apache.org/dist/incubator/tubemq/0.7.0-incubating/apache-tubemq-0.7.0-incubating-src.tar.gz.asc)]        [[SHA512](https://archive.apache.org/dist/incubator/tubemq/0.7.0-incubating/apache-tubemq-0.7.0-incubating-src.tar.gz.sha512)]
+ - Client: [tubemq-client-0.7.0-incubating-bin.tar.gz](https://archive.apache.org/dist/incubator/tubemq/0.7.0-incubating/apache-tubemq-client-0.7.0-incubating-bin.tar.gz)       [[ASC](https://archive.apache.org/dist/incubator/tubemq/0.7.0-incubating/apache-tubemq-client-0.7.0-incubating-bin.tar.gz.asc)] [[SHA512](https://archive.apache.org/dist/incubator/tubemq/0.7.0-incubating/apache-tubemq-client-0.7.0-incubating-bin.tar.gz.sha512)]
+ - Server: [tubemq-server-0.7.0-incubating-bin.tar.gz](https://archive.apache.org/dist/incubator/tubemq/0.7.0-incubating/apache-tubemq-server-0.7.0-incubating-bin.tar.gz)       [[ASC](https://archive.apache.org/dist/incubator/tubemq/0.7.0-incubating/apache-tubemq-server-0.7.0-incubating-bin.tar.gz.asc)] [[SHA512](https://archive.apache.org/dist/incubator/tubemq/0.7.0-incubating/apache-tubemq-server-0.7.0-incubating-bin.tar.gz.sha512)]
+
+## 0.6.0 release
+
+ - Released: October 21th, 2020
+ - [Release Notes](release-0.6.0.md)
+ - Source: [tubemq-0.6.0-incubating-src.tar.gz](https://archive.apache.org/dist/incubator/tubemq/0.6.0-incubating/apache-tubemq-0.6.0-incubating-src.tar.gz)              [[ASC](https://archive.apache.org/dist/incubator/tubemq/0.6.0-incubating/apache-tubemq-0.6.0-incubating-src.tar.gz.asc)]        [[SHA512](https://archive.apache.org/dist/incubator/tubemq/0.6.0-incubating/apache-tubemq-0.6.0-incubating-src.tar.gz.sha512)]
+ - Client: [tubemq-client-0.6.0-incubating-bin.tar.gz](https://archive.apache.org/dist/incubator/tubemq/0.6.0-incubating/apache-tubemq-client-0.6.0-incubating-bin.tar.gz)       [[ASC](https://archive.apache.org/dist/incubator/tubemq/0.6.0-incubating/apache-tubemq-client-0.6.0-incubating-bin.tar.gz.asc)] [[SHA512](https://archive.apache.org/dist/incubator/tubemq/0.6.0-incubating/apache-tubemq-client-0.6.0-incubating-bin.tar.gz.sha512)]
+ - Server: [tubemq-server-0.6.0-incubating-bin.tar.gz](https://archive.apache.org/dist/incubator/tubemq/0.6.0-incubating/apache-tubemq-server-0.6.0-incubating-bin.tar.gz)       [[ASC](https://archive.apache.org/dist/incubator/tubemq/0.6.0-incubating/apache-tubemq-server-0.6.0-incubating-bin.tar.gz.asc)] [[SHA512](https://archive.apache.org/dist/incubator/tubemq/0.6.0-incubating/apache-tubemq-server-0.6.0-incubating-bin.tar.gz.sha512)]
+
+## 0.5.0 release
+ - Released: August 4th, 2020
+ - [Release Notes](release-0.5.0.md)
+ - Source: [tubemq-0.5.0-incubating-src.tar.gz](https://archive.apache.org/dist/incubator/tubemq/0.5.0-incubating/apache-tubemq-0.5.0-incubating-src.tar.gz)              [[ASC](https://archive.apache.org/dist/incubator/tubemq/0.5.0-incubating/apache-tubemq-0.5.0-incubating-src.tar.gz.asc)]        [[SHA512](https://archive.apache.org/dist/incubator/tubemq/0.5.0-incubating/apache-tubemq-0.5.0-incubating-src.tar.gz.sha512)]
+ - Client: [tubemq-client-0.5.0-incubating-bin.tar.gz](https://archive.apache.org/dist/incubator/tubemq/0.5.0-incubating/apache-tubemq-client-0.5.0-incubating-bin.tar.gz)       [[ASC](https://archive.apache.org/dist/incubator/tubemq/0.5.0-incubating/apache-tubemq-client-0.5.0-incubating-bin.tar.gz.asc)] [[SHA512](https://archive.apache.org/dist/incubator/tubemq/0.5.0-incubating/apache-tubemq-client-0.5.0-incubating-bin.tar.gz.sha512)]
+ - Server: [tubemq-server-0.5.0-incubating-bin.tar.gz](https://archive.apache.org/dist/incubator/tubemq/0.5.0-incubating/apache-tubemq-server-0.5.0-incubating-bin.tar.gz)       [[ASC](https://archive.apache.org/dist/incubator/tubemq/0.5.0-incubating/apache-tubemq-server-0.5.0-incubating-bin.tar.gz.asc)] [[SHA512](https://archive.apache.org/dist/incubator/tubemq/0.5.0-incubating/apache-tubemq-server-0.5.0-incubating-bin.tar.gz.sha512)]
+
+## 0.3.0 release
+ - Released: June 6th, 2020
+ - [Release Notes](release-0.3.0.md)
+ - Source: [tubemq-0.3.0-incubating-src.tar.gz](https://archive.apache.org/dist/incubator/tubemq/0.3.0-incubating/apache-tubemq-0.3.0-incubating-src.tar.gz)              [[ASC](https://archive.apache.org/dist/incubator/tubemq/0.3.0-incubating/apache-tubemq-0.3.0-incubating-src.tar.gz.asc)]        [[SHA512](https://archive.apache.org/dist/incubator/tubemq/0.3.0-incubating/apache-tubemq-0.3.0-incubating-src.tar.gz.sha512)]
+ - Client: [tubemq-client-0.3.0-incubating-bin.tar.gz](https://archive.apache.org/dist/incubator/tubemq/0.3.0-incubating/apache-tubemq-client-0.3.0-incubating-bin.tar.gz)       [[ASC](https://archive.apache.org/dist/incubator/tubemq/0.3.0-incubating/apache-tubemq-client-0.3.0-incubating-bin.tar.gz.asc)] [[SHA512](https://archive.apache.org/dist/incubator/tubemq/0.3.0-incubating/apache-tubemq-client-0.3.0-incubating-bin.tar.gz.sha512)]
+ - Server: [tubemq-server-0.3.0-incubating-bin.tar.gz](https://archive.apache.org/dist/incubator/tubemq/0.3.0-incubating/apache-tubemq-server-0.3.0-incubating-bin.tar.gz)       [[ASC](https://archive.apache.org/dist/incubator/tubemq/0.3.0-incubating/apache-tubemq-server-0.3.0-incubating-bin.tar.gz.asc)] [[SHA512](https://archive.apache.org/dist/incubator/tubemq/0.3.0-incubating/apache-tubemq-server-0.3.0-incubating-bin.tar.gz.sha512)]

--- a/download/release-0.10.0.md
+++ b/download/release-0.10.0.md
@@ -1,0 +1,148 @@
+---
+title: 0.10.0
+---
+
+# Download the InLong releases
+
+Use the links below to download the Apache InLong from one of our mirrors.
+
+## InLong
+| Date | Version| Comment | Downloads |
+|:---:|:--:|:--:|:--:|
+| Sept 11, 2021 | 0.10.0 | Source | [[SRC](http://www.apache.org/dyn/closer.lua/incubator/inlong/0.10.0-incubating/apache-inlong-0.10.0-incubating-src.tar.gz)]                 [[ASC](https://downloads.apache.org/incubator/inlong/0.10.0-incubating/apache-inlong-0.10.0-incubating-src.tar.gz.asc)]             [[SHA512](https://downloads.apache.org/incubator/inlong/0.10.0-incubating/apache-inlong-0.10.0-incubating-src.tar.gz.sha512)] |
+
+
+### Release Integrity
+   You must [verify](https://www.apache.org/info/verification.html) the integrity of the downloaded files. We provide OpenPGP signatures for every release file. This signature should be matched against the [KEYS](https://downloads.apache.org/incubator/inlong/KEYS) file which contains the OpenPGP keys of InLong's Release Managers. We also provide <code>SHA-512</code> checksums for every release file. After you download the file, you should calculate a checksum for your download, and make sure it is the same as ours.
+
+
+## Release Notes
+
+### IMPROVEMENTS:
+| ISSUE  | Summary  |
+| :---- | :------- |
+| [INLONG-570](https://issues.apache.org/jira/browse/INLONG-570) | Optimizing the implementations of HTTP API for Master
+| [INLONG-726](https://issues.apache.org/jira/browse/INLONG-726) | Optimize The Deployment For InLong
+| [INLONG-732](https://issues.apache.org/jira/browse/INLONG-732) | Optimize the CI/CD workflow for build and integration test
+| [INLONG-733](https://issues.apache.org/jira/browse/INLONG-733) | Unity the Manger-API/Manger-OpenAPI, and change Manager-API to Manager-Web
+| [INLONG-744](https://issues.apache.org/jira/browse/INLONG-744) | Error log, should use log4j
+| [INLONG-750](https://issues.apache.org/jira/browse/INLONG-750) | Add configuration descriptions for 'defEthName' in 'broker.ini'
+| [INLONG-756](https://issues.apache.org/jira/browse/INLONG-756) | package start.sh script executable for agent
+| [INLONG-768](https://issues.apache.org/jira/browse/INLONG-768) | add github pull request template
+| [INLONG-789](https://issues.apache.org/jira/browse/INLONG-789) | make agent readme more friendly
+| [INLONG-792](https://issues.apache.org/jira/browse/INLONG-792) | tubemanager add a cluster after configuration
+| [INLONG-800](https://issues.apache.org/jira/browse/INLONG-800) | Fix codestyle of some comments and methods names.
+| [INLONG-804](https://issues.apache.org/jira/browse/INLONG-804) | Optimize the ASF Configuration
+| [INLONG-805](https://issues.apache.org/jira/browse/INLONG-805) | Migrate InLong Issues from JIRA to GitHub
+| [INLONG-808](https://issues.apache.org/jira/browse/INLONG-808) | Missing dataproxy sdk readme
+| [INLONG-809](https://issues.apache.org/jira/browse/INLONG-809) | dataproxy readme delete reference url
+| [INLONG-1498](https://github.com/apache/incubator-inlong/issues/1498) |  ignore the files with versionsBackup suffix for the bumped version
+| [INLONG-1487](https://github.com/apache/incubator-inlong/issues/1487) |  remove the user number limit  when create a new data stream
+| [INLONG-1486](https://github.com/apache/incubator-inlong/issues/1486) |  [agent] update the document about configuring the dataprxy address
+| [INLONG-1485](https://github.com/apache/incubator-inlong/issues/1485) |  [sort] add the guide documents for using Pulsar
+| [INLONG-1484](https://github.com/apache/incubator-inlong/issues/1484) |  Bid and Tid is not well explained in agent and might cause send error
+| [INLONG-1464](https://github.com/apache/incubator-inlong/issues/1464) |  Add code CheckStyle rules
+| [INLONG-1459](https://github.com/apache/incubator-inlong/issues/1459) |  proxy address configuration is redundant for inlong-agent
+| [INLONG-1457](https://github.com/apache/incubator-inlong/issues/1457) |  remove the user limit for creating a new data access
+| [INLONG-1455](https://github.com/apache/incubator-inlong/issues/1455) |  add a script to publish docker images
+| [INLONG-1443](https://github.com/apache/incubator-inlong/issues/1443) |   Provide management interface SDK
+| [INLONG-1439](https://github.com/apache/incubator-inlong/issues/1439) |  Add the port legal check and remove the useless deleteWhen field
+| [INLONG-1430](https://github.com/apache/incubator-inlong/issues/1430) |  Go SDK example
+| [INLONG-1429](https://github.com/apache/incubator-inlong/issues/1429) |  update the asf config for inlong office website
+| [INLONG-1427](https://github.com/apache/incubator-inlong/issues/1427) |  Go SDK return maxOffset and updateTime in ConsumerOffset
+| [INLONG-1424](https://github.com/apache/incubator-inlong/issues/1424) |  change the format of the configuration file: make the yaml to properties
+| [INLONG-1423](https://github.com/apache/incubator-inlong/issues/1423) |  modify the docker image of the inlong-manager module
+| [INLONG-1417](https://github.com/apache/incubator-inlong/issues/1417) |  rename the distribution file for inlong
+| [INLONG-1415](https://github.com/apache/incubator-inlong/issues/1415) |  [TubeMQ Docker] expose zookeeper port for other component usages
+| [INLONG-1409](https://github.com/apache/incubator-inlong/issues/1409) |  Sort out the LICENSE information of the 3rd-party components that the DataProxy submodule depends on
+| [INLONG-1407](https://github.com/apache/incubator-inlong/issues/1407) |  [DataProxy]Adjust the pom dependency of the DataProxy module
+| [INLONG-1405](https://github.com/apache/incubator-inlong/issues/1405) |  too many issues mail at dev@inlong mailbox
+
+### BUG FIXES:
+| ISSUE  | Summary  |
+| :---- | :------- |
+| [INLONG-751](https://issues.apache.org/jira/browse/INLONG-751) | InLong Manager start up error
+| [INLONG-776](https://issues.apache.org/jira/browse/INLONG-776) | fix the version error for tubemq cpp client docker image
+| [INLONG-777](https://issues.apache.org/jira/browse/INLONG-777) | InLong Manager new data stream error
+| [INLONG-782](https://issues.apache.org/jira/browse/INLONG-782) | Optimize The PULL_REQUEST_TEMPLATE
+| [INLONG-787](https://issues.apache.org/jira/browse/INLONG-787) | The actions "reviewdog/action-setup" is not allowed to be used
+| [INLONG-797](https://issues.apache.org/jira/browse/INLONG-797) | the document for deployment DataProxy is not complete
+| [INLONG-799](https://issues.apache.org/jira/browse/INLONG-799) | can not find common.properties for dataproxy
+| [INLONG-1488](https://github.com/apache/incubator-inlong/issues/1488) |  there are still some chinese characters for website
+| [INLONG-1475](https://github.com/apache/incubator-inlong/issues/1475) |  Tube manager compile ch.qos.logback with error
+| [INLONG-1474](https://github.com/apache/incubator-inlong/issues/1474) |  the interface of get data proxy configurations got abnormal status result
+| [INLONG-1470](https://github.com/apache/incubator-inlong/issues/1470) |  Java.util.ConcurrentModificationException error when rebalance
+| [INLONG-1468](https://github.com/apache/incubator-inlong/issues/1468) |  The update interval of dataproxy is quite long and may cause produce error when config is not updated
+| [INLONG-1466](https://github.com/apache/incubator-inlong/issues/1466) |  get snappy error when the agent collecting data
+| [INLONG-1462](https://github.com/apache/incubator-inlong/issues/1462) |  dataproxy can not create configuration properties successfully in the docker container
+| [INLONG-1458](https://github.com/apache/incubator-inlong/issues/1458) |  The http port in agent readme should be 8008 to be consistent with the code
+| [INLONG-1453](https://github.com/apache/incubator-inlong/issues/1453) |  agent connect dataproxy fail when using docker-compose
+| [INLONG-1448](https://github.com/apache/incubator-inlong/issues/1448) |  The Manager throws an exception when creating a business
+| [INLONG-1447](https://github.com/apache/incubator-inlong/issues/1447) |  Fix Group Control API logic bug
+| [INLONG-1444](https://github.com/apache/incubator-inlong/issues/1444) |  Fix Web API multiple field search logic bug
+| [INLONG-1441](https://github.com/apache/incubator-inlong/issues/1441) |  Repair Broker configuration API bugs
+| [INLONG-1436](https://github.com/apache/incubator-inlong/issues/1436) |  [CI] The checkstyle workflow is redundant
+| [INLONG-1432](https://github.com/apache/incubator-inlong/issues/1432) |  The manager url of agent and dataproxy need to be updated since manager merged openapi and api into one module
+| [INLONG-1403](https://github.com/apache/incubator-inlong/issues/1403) |  fix some error in dataproxy-sdk readme
+
+### SUB-TASK:
+| ISSUE  | Summary  |
+| :---- | :------- |
+| [INLONG-576](https://issues.apache.org/jira/browse/INLONG-576) | Build metadata entity classes
+| [INLONG-578](https://issues.apache.org/jira/browse/INLONG-578) | Build implementation classes based on BDB storage
+| [INLONG-579](https://issues.apache.org/jira/browse/INLONG-579) | Add structure mapping of BDB and metadata entity classes
+| [INLONG-580](https://issues.apache.org/jira/browse/INLONG-580) | Build active and standby keep-alive services
+| [INLONG-581](https://issues.apache.org/jira/browse/INLONG-581) | Add data cache in BDB metadata Mapper implementations
+| [INLONG-582](https://issues.apache.org/jira/browse/INLONG-582) | Adjust the business logic related to the BdbClusterSettingEntity class
+| [INLONG-583](https://issues.apache.org/jira/browse/INLONG-583) | Adjust BrokerConfManager class implementation
+| [INLONG-584](https://issues.apache.org/jira/browse/INLONG-584) | Adjust WebMasterInfoHandler class implementation
+| [INLONG-593](https://issues.apache.org/jira/browse/INLONG-593) | Add WebGroupConsumeCtrlHandler class implementation
+| [INLONG-595](https://issues.apache.org/jira/browse/INLONG-595) | Add WebBrokerConfHandler class implementation
+| [INLONG-596](https://issues.apache.org/jira/browse/INLONG-596) | Add WebTopicConfHandler class implementation
+| [INLONG-597](https://issues.apache.org/jira/browse/INLONG-597) | Adjust WebTopicCtrlHandler class implementation
+| [INLONG-598](https://issues.apache.org/jira/browse/INLONG-598) | Adjust WebTopicCtrlHandler class implementation
+| [INLONG-599](https://issues.apache.org/jira/browse/INLONG-599) | Adjust WebParameterUtils.java's static functions
+| [INLONG-601](https://issues.apache.org/jira/browse/INLONG-601) | Adjust WebBrokerDefConfHandler class implementation
+| [INLONG-602](https://issues.apache.org/jira/browse/INLONG-602) | Add replacement processing after metadata changes
+| [INLONG-611](https://issues.apache.org/jira/browse/INLONG-611) | Add FSM for broker configure manage
+| [INLONG-617](https://issues.apache.org/jira/browse/INLONG-617) | Add unit tests for WebParameterUtils
+| [INLONG-618](https://issues.apache.org/jira/browse/INLONG-618) | Add unit tests for metastore.dao.entity.*
+| [INLONG-625](https://issues.apache.org/jira/browse/INLONG-625) | Add unit tests for metamanage.metastore.impl.*
+| [INLONG-626](https://issues.apache.org/jira/browse/INLONG-626) | Fix broker and topic confiugre implement bugs
+| [INLONG-707](https://issues.apache.org/jira/browse/INLONG-707) | Bumped version to 0.10.0-SNAPSHOT
+| [INLONG-740](https://issues.apache.org/jira/browse/INLONG-740) | Merge the changes in INLONG-739 to master and delete the temporary branch
+| [INLONG-755](https://issues.apache.org/jira/browse/INLONG-755) | Go SDK Consumer Result
+| [INLONG-757](https://issues.apache.org/jira/browse/INLONG-757) | fix the artifactId of dataproxy
+| [INLONG-758](https://issues.apache.org/jira/browse/INLONG-758) | remove redundant baseDirectory for manager output files
+| [INLONG-759](https://issues.apache.org/jira/browse/INLONG-759) | fix assembly issue for TubeMQ manager
+| [INLONG-760](https://issues.apache.org/jira/browse/INLONG-760) | standardize the directories name for the sort sub-module
+| [INLONG-761](https://issues.apache.org/jira/browse/INLONG-761) | unify all modules target files to a singe directory
+| [INLONG-762](https://issues.apache.org/jira/browse/INLONG-762) | refactor the deployment document
+| [INLONG-763](https://issues.apache.org/jira/browse/INLONG-763) | make the inlong-websit be a maven module of InLong project
+| [INLONG-764](https://issues.apache.org/jira/browse/INLONG-764) | Fix Go SDK RPC Request bug
+| [INLONG-766](https://issues.apache.org/jira/browse/INLONG-766) | Fix Go SDK Codec Bug
+| [INLONG-770](https://issues.apache.org/jira/browse/INLONG-770) | update the readme document
+| [INLONG-771](https://issues.apache.org/jira/browse/INLONG-771) | Fix Go SDK Authorization Bug
+| [INLONG-773](https://issues.apache.org/jira/browse/INLONG-773) | add manager docker image
+| [INLONG-774](https://issues.apache.org/jira/browse/INLONG-774) | update TubeMQ docker images to InLong repo
+| [INLONG-778](https://issues.apache.org/jira/browse/INLONG-778) | Fix Go SDK Consumer Bug
+| [INLONG-779](https://issues.apache.org/jira/browse/INLONG-779) | update tubemq manager docker image
+| [INLONG-781](https://issues.apache.org/jira/browse/INLONG-781) | add inlong agent docker image support
+| [INLONG-784](https://issues.apache.org/jira/browse/INLONG-784) | Fix Go SDK Heartbeat Bug
+| [INLONG-785](https://issues.apache.org/jira/browse/INLONG-785) | Fix Go SDK Metadata Bug
+| [INLONG-786](https://issues.apache.org/jira/browse/INLONG-786) | add dataproxy docker image
+| [INLONG-788](https://issues.apache.org/jira/browse/INLONG-788) | Fix Go SDK Remote Cache Bug
+| [INLONG-791](https://issues.apache.org/jira/browse/INLONG-791) | Go SDK Support multiple topic address
+| [INLONG-793](https://issues.apache.org/jira/browse/INLONG-793) | Fix Some Corner Case in Go SDK
+| [INLONG-794](https://issues.apache.org/jira/browse/INLONG-794) | add website docker image
+| [INLONG-803](https://issues.apache.org/jira/browse/INLONG-803) | add docker requirement for building InLong
+| [INLONG-806](https://issues.apache.org/jira/browse/INLONG-806) | open GitHub Issue For InLong
+| [INLONG-807](https://issues.apache.org/jira/browse/INLONG-807) | migrate issue history to inlong
+| [INLONG-1491](https://github.com/apache/incubator-inlong/issues/1491) |  Add 0.10.0 version release modification to CHANGES.md
+| [INLONG-1492](https://github.com/apache/incubator-inlong/issues/1492) |  Bumped version to 0.11.0-incubating-SNAPSHOT
+| [INLONG-1493](https://github.com/apache/incubator-inlong/issues/1493) |  Modify download&release notes for 0.10.0
+| [INLONG-1494](https://github.com/apache/incubator-inlong/issues/1494) |  Adjust the version information of all pom.xml to 0.10.0-incubating
+| [INLONG-1495](https://github.com/apache/incubator-inlong/issues/1495) |  Update Office website content for release 0.10.0
+| [INLONG-1496](https://github.com/apache/incubator-inlong/issues/1496) |  Release InLong 0.10.0
+| [INLONG-1497](https://github.com/apache/incubator-inlong/issues/1497) |  create a 0.10.0 branch to release
+| [INLONG-1502](https://github.com/apache/incubator-inlong/issues/1502) |  publish all 0.10.0 images to docker hub

--- a/download/release-0.3.0.md
+++ b/download/release-0.3.0.md
@@ -1,0 +1,65 @@
+---
+title: 0.3.0
+---
+
+# Download the InLong releases
+
+Use the links below to download the Apache InLong from one of our mirrors.
+
+## InLong
+| Date | Version| Comment | Downloads |
+|:---:|:--:|:--:|:--:|
+| June. 6th, 2020 | 0.3.0 | Source | [[SRC](https://archive.apache.org/dist/incubator/tubemq/0.3.0-incubating/apache-tubemq-0.3.0-incubating-src.tar.gz)]                 [[PGP](https://archive.apache.org/dist/incubator/tubemq/0.3.0-incubating/apache-tubemq-0.3.0-incubating-src.tar.gz.asc)]             [[SHA512](https://archive.apache.org/dist/incubator/tubemq/0.3.0-incubating/apache-tubemq-0.3.0-incubating-src.tar.gz.sha512)] |
+| |                       | Client | [[TAR](https://archive.apache.org/dist/incubator/tubemq/0.3.0-incubating/apache-tubemq-client-0.3.0-incubating-bin.tar.gz)]          [[PGP](archive.apache.org/dist/incubator/tubemq/0.3.0-incubating/apache-tubemq-client-0.3.0-incubating-bin.tar.gz.asc)]      [[SHA512](https://archive.apache.org/dist/incubator/tubemq/0.3.0-incubating/apache-tubemq-client-0.3.0-incubating-bin.tar.gz.sha512)] |
+| |                       | Server | [[TAR](https://archive.apache.org/dist/incubator/tubemq/0.3.0-incubating/apache-tubemq-server-0.3.0-incubating-bin.tar.gz)]          [[PGP](https://archive.apache.org/dist/incubator/tubemq/0.3.0-incubating/apache-tubemq-server-0.3.0-incubating-bin.tar.gz.asc)]      [[SHA512](https://archive.apache.org/dist/incubator/tubemq/0.3.0-incubating/apache-tubemq-server-0.3.0-incubating-bin.tar.gz.sha512)] |
+
+
+## Release Notes
+
+### New Features
+ - [[INLONG-42](https://issues.apache.org/jira/browse/INLONG-42)] Add peer information about message received Major New Feature
+ 
+### Improvements
+ - [[INLONG-7](https://issues.apache.org/jira/browse/INLONG-7)] Using StringBuilder instead of StringBuffer in BaseResult
+ - [[INLONG-9](https://issues.apache.org/jira/browse/INLONG-9)] Remove some unnecessary code
+ - [[INLONG-16](https://issues.apache.org/jira/browse/INLONG-16)] Correct BdbStoreService#isPrimaryNodeActived to BdbStoreService#isPrimaryNodeActive
+ - [[INLONG-18](https://issues.apache.org/jira/browse/INLONG-18)] Correct TMaster#idGenerater to TMaster#idGenerator
+ - [[INLONG-19](https://issues.apache.org/jira/browse/INLONG-19)] Correct parameter names to fit in camel case
+ - [[INLONG-20](https://issues.apache.org/jira/browse/INLONG-20)] Correct DefaultLoadBalancer#balance parameter
+ - [[INLONG-21](https://issues.apache.org/jira/browse/INLONG-21)] Change version number from x.y-SNAPSHOT to x.y.z-incubating-SNAPSHOT
+ - [[INLONG-22](https://issues.apache.org/jira/browse/INLONG-22)] Correct ClientSubInfo#getTopicProcesser -> ClientSubInfo#getTopicProcessor
+ - [[INLONG-23](https://issues.apache.org/jira/browse/INLONG-23)] Improve project README content introduction
+ - [[INLONG-24](https://issues.apache.org/jira/browse/INLONG-24)] Add NOTICE and adjust LICENSE
+ - [[INLONG-26](https://issues.apache.org/jira/browse/INLONG-26)] correct spelling (difftime-> diffTime)
+ - [[INLONG-27](https://issues.apache.org/jira/browse/INLONG-27)] replace StringBuffer with StringBuilder
+ - [[INLONG-28](https://issues.apache.org/jira/browse/INLONG-28)] ignore path error
+ - [[INLONG-29](https://issues.apache.org/jira/browse/INLONG-29)] Change the package name to org.apache.tubemq.""
+ - [[INLONG-33](https://issues.apache.org/jira/browse/INLONG-33)] refactor enum implement from annoymouse inner class
+ - [[INLONG-38](https://issues.apache.org/jira/browse/INLONG-38)] Correct DefaultLoadBalancer#balance parameter
+ - [[INLONG-39](https://issues.apache.org/jira/browse/INLONG-39)] Optimize the loadMessageStores() logic
+ - [[INLONG-40](https://issues.apache.org/jira/browse/INLONG-40)] Optimize message disk store classes's logic
+ - [[INLONG-43](https://issues.apache.org/jira/browse/INLONG-43)] Add DeletePolicy's value check
+ - [[INLONG-44](https://issues.apache.org/jira/browse/INLONG-44)] Remove unnecessary synchronized definition of shutdown () function
+ - [[INLONG-49](https://issues.apache.org/jira/browse/INLONG-49)] setTimeoutTime change to updTimeoutTime
+ - [[INLONG-50](https://issues.apache.org/jira/browse/INLONG-50)] Replace fastjson to gson
+ 
+ 
+### Bug Fixes
+ - [[INLONG-10](https://issues.apache.org/jira/browse/INLONG-10)] Fix Javadoc error
+ - [[INLONG-14](https://issues.apache.org/jira/browse/INLONG-14)] Some compilation errors
+ - [[INLONG-15](https://issues.apache.org/jira/browse/INLONG-15)] Correct typo in http_access_API_definition.md
+ - [[INLONG-32](https://issues.apache.org/jira/browse/INLONG-32)] File path not match with package name in tubemq-client module
+ - [[INLONG-35](https://issues.apache.org/jira/browse/INLONG-35)] check illegal package's field value
+ - [[INLONG-36](https://issues.apache.org/jira/browse/INLONG-36)] Remove unnecessary removefirst() function printing
+ - [[INLONG-37](https://issues.apache.org/jira/browse/INLONG-37)] Offset is set to 0 when Broker goes offline
+ - [[INLONG-45](https://issues.apache.org/jira/browse/INLONG-45)] Check groupName with checkHostName function
+ - [[INLONG-48](https://issues.apache.org/jira/browse/INLONG-48)] No timeout when setting consumer timeout
+ - [[INLONG-59](https://issues.apache.org/jira/browse/INLONG-59)] Null pointer exception is thrown while constructing ConsumerConfig with MasterInfo
+ - [[INLONG-62](https://issues.apache.org/jira/browse/INLONG-62)] consumed and set consumerConfig.setConsumeModel (0) for the first time
+ - [[INLONG-66](https://issues.apache.org/jira/browse/INLONG-66)] TubeSingleSessionFactory shutdown bug
+ - [[INLONG-85](https://issues.apache.org/jira/browse/INLONG-85)] There is NPE when creating PullConsumer with TubeSingleSessionFactory
+ - [[INLONG-88](https://issues.apache.org/jira/browse/INLONG-88)] Broker does not take effect after the deletePolicy value is changed
+ - [[INLONG-149](https://issues.apache.org/jira/browse/INLONG-149)] Some of the consumers stop consuming their corresponding partitions and never release the partition to others
+ - [[INLONG-153](https://issues.apache.org/jira/browse/INLONG-153)] Some of the consumers stop consuming their corresponding partitions and never release the partition to others
+ - [[INLONG-165](https://issues.apache.org/jira/browse/INLONG-165)] Remove unnecessary fiiles
+ 

--- a/download/release-0.5.0.md
+++ b/download/release-0.5.0.md
@@ -1,0 +1,104 @@
+---
+title: 0.5.0
+---
+
+# Download the InLong releases
+
+Use the links below to download the Apache InLong from one of our mirrors.
+
+## InLong
+| Date | Version| Comment | Downloads |
+|:---:|:--:|:--:|:--:|
+| August. 4th, 2020 | 0.5.0 | Source | [[SRC](https://archive.apache.org/dist/incubator/tubemq/0.5.0-incubating/apache-tubemq-0.5.0-incubating-src.tar.gz)]                 [[PGP](https://archive.apache.org/dist/incubator/tubemq/0.5.0-incubating/apache-tubemq-0.5.0-incubating-src.tar.gz.asc)]             [[SHA512](https://archive.apache.org/dist/incubator/tubemq/0.5.0-incubating/apache-tubemq-0.5.0-incubating-src.tar.gz.sha512)] |
+| |                       | Client | [[TAR](https://archive.apache.org/dist/incubator/tubemq/0.5.0-incubating/apache-tubemq-client-0.5.0-incubating-bin.tar.gz)]          [[PGP](https://archive.apache.org/dist/incubator/tubemq/0.5.0-incubating/apache-tubemq-client-0.5.0-incubating-bin.tar.gz.asc)]      [[SHA512](https://archive.apache.org/dist/incubator/tubemq/0.5.0-incubating/apache-tubemq-client-0.5.0-incubating-bin.tar.gz.sha512)] |
+| |                       | Server | [[TAR](https://archive.apache.org/dist/incubator/tubemq/0.5.0-incubating/apache-tubemq-server-0.5.0-incubating-bin.tar.gz)]          [[PGP](https://archive.apache.org/dist/incubator/tubemq/0.5.0-incubating/apache-tubemq-server-0.5.0-incubating-bin.tar.gz.asc)]      [[SHA512](https://archive.apache.org/dist/incubator/tubemq/0.5.0-incubating/apache-tubemq-server-0.5.0-incubating-bin.tar.gz.sha512)] |
+
+
+## Release Notes
+
+### New Features
+ - [[INLONG-122](https://issues.apache.org/jira/browse/INLONG-122)] Increase JAVA version collection of SDK environment
+ - [[INLONG-163](https://issues.apache.org/jira/browse/INLONG-163)] Flume sink for TubeMQ
+ - [[INLONG-197](https://issues.apache.org/jira/browse/INLONG-197)] Support TubeMQ connector for Apache Flink
+ - [[INLONG-238](https://issues.apache.org/jira/browse/INLONG-238)] Support TubeMQ connector for Apache Spark Streaming
+ - [[INLONG-239](https://issues.apache.org/jira/browse/INLONG-239)] support deployment on kubernetes
+
+### IMPROVEMENTS:
+ - [[INLONG-46](https://issues.apache.org/jira/browse/INLONG-46)] Correct some spelling issues
+ - [[INLONG-53](https://issues.apache.org/jira/browse/INLONG-53)] fix some typos
+ - [[INLONG-55](https://issues.apache.org/jira/browse/INLONG-55)] fix some typos
+ - [[INLONG-57](https://issues.apache.org/jira/browse/INLONG-57)] fix some typos
+ - [[INLONG-58](https://issues.apache.org/jira/browse/INLONG-58)] fix some typos
+ - [[INLONG-60](https://issues.apache.org/jira/browse/INLONG-60)] Remove unnecessary synchronized & using IllegalArgumentException instead of IllegalStateException
+ - [[INLONG-61](https://issues.apache.org/jira/browse/INLONG-61)] minor update & fix some typos
+ - [[INLONG-64](https://issues.apache.org/jira/browse/INLONG-64)] minor update & fix some typos
+ - [[INLONG-67](https://issues.apache.org/jira/browse/INLONG-67)] remove synchronized & fix some typos
+ - [[INLONG-71](https://issues.apache.org/jira/browse/INLONG-71)] using IllegalArgumentException & fix some typos
+ - [[INLONG-73](https://issues.apache.org/jira/browse/INLONG-73)] remove duplicate codes & some minor updates
+ - [[INLONG-74](https://issues.apache.org/jira/browse/INLONG-74)] minor updates for DefaultBdbStoreService
+ - [[INLONG-75](https://issues.apache.org/jira/browse/INLONG-75)] remove unused Logger
+ - [[INLONG-76](https://issues.apache.org/jira/browse/INLONG-76)] rename the classes
+ - [[INLONG-77](https://issues.apache.org/jira/browse/INLONG-77)] fix typo
+ - [[INLONG-79](https://issues.apache.org/jira/browse/INLONG-79)] fix typo
+ - [[INLONG-80](https://issues.apache.org/jira/browse/INLONG-80)] Fix some typos
+ - [[INLONG-82](https://issues.apache.org/jira/browse/INLONG-82)] Fix some typos & update comments
+ - [[INLONG-83](https://issues.apache.org/jira/browse/INLONG-83)] Fix some typos
+ - [[INLONG-87](https://issues.apache.org/jira/browse/INLONG-87)] Minor updates
+ - [[INLONG-89](https://issues.apache.org/jira/browse/INLONG-89)] Minor updates
+ - [[INLONG-90](https://issues.apache.org/jira/browse/INLONG-90)] Remove unused codes in TubeBroker
+ - [[INLONG-91](https://issues.apache.org/jira/browse/INLONG-91)] replace explicit type with `<>`
+ - [[INLONG-93](https://issues.apache.org/jira/browse/INLONG-93)] Substitute the parameterized type for client module & missed server module
+ - [[INLONG-94](https://issues.apache.org/jira/browse/INLONG-94)] Substitute the parameterized type for core module
+ - [[INLONG-95](https://issues.apache.org/jira/browse/INLONG-95)] Substitute the parameterized type for server module
+ - [[INLONG-96](https://issues.apache.org/jira/browse/INLONG-96)] Fix typo & use IllegalArgumentException
+ - [[INLONG-98](https://issues.apache.org/jira/browse/INLONG-98)] Fix typo & Simplify 'instanceof' judgment
+ - [[INLONG-100](https://issues.apache.org/jira/browse/INLONG-100)] Fix typos & remove unused codes
+ - [[INLONG-101](https://issues.apache.org/jira/browse/INLONG-101)] Optimize code & Fix type
+ - [[INLONG-103](https://issues.apache.org/jira/browse/INLONG-103)] Substitute Chinese comments with English
+ - [[INLONG-108](https://issues.apache.org/jira/browse/INLONG-108)] About maven jdk version configuration problem
+ - [[INLONG-127](https://issues.apache.org/jira/browse/INLONG-127)] Fixed a bug & minor changes
+ - [[INLONG-128](https://issues.apache.org/jira/browse/INLONG-128)] Shorten the log clearup check cycle
+ - [[INLONG-138](https://issues.apache.org/jira/browse/INLONG-138)] Optimize core module test case code
+ - [[INLONG-141](https://issues.apache.org/jira/browse/INLONG-141)] Remove the requirement to provide localHostIP
+ - [[INLONG-152](https://issues.apache.org/jira/browse/INLONG-152)] Modify the master.ini file's annotations
+ - [[INLONG-154](https://issues.apache.org/jira/browse/INLONG-154)] Modify the wrong comment & Minor changes for example module
+ - [[INLONG-155](https://issues.apache.org/jira/browse/INLONG-155)] Use enum class for consume position
+ - [[INLONG-156](https://issues.apache.org/jira/browse/INLONG-156)] Update for README.md
+ - [[INLONG-166](https://issues.apache.org/jira/browse/INLONG-166)] Hide `bdbStore` configs in master.ini
+ - [[INLONG-167](https://issues.apache.org/jira/browse/INLONG-167)] Change to relative paths in default configs
+ - [[INLONG-168](https://issues.apache.org/jira/browse/INLONG-168)] Example module: remove localhost IP configuration parameters
+ - [[INLONG-170](https://issues.apache.org/jira/browse/INLONG-170)] improve build/deployment/configuration for quick start
+ - [[INLONG-196](https://issues.apache.org/jira/browse/INLONG-196)] use log to print exception
+ - [[INLONG-201](https://issues.apache.org/jira/browse/INLONG-201)] [Website] Adjust user guide & fix demo example
+ - [[INLONG-202](https://issues.apache.org/jira/browse/INLONG-202)] Add protobuf protocol syntax declaration
+ - [[INLONG-213](https://issues.apache.org/jira/browse/INLONG-213)] Optimize code & Minor changes
+ - [[INLONG-216](https://issues.apache.org/jira/browse/INLONG-216)] use ThreadUtil.sleep replace Thread.sleep
+ - [[INLONG-222](https://issues.apache.org/jira/browse/INLONG-222)] Optimize code: Unnecessary boxing/unboxing conversion
+ - [[INLONG-224](https://issues.apache.org/jira/browse/INLONG-224)] Fixed: Unnecessary conversion to string inspection for server module
+ - [[INLONG-226](https://issues.apache.org/jira/browse/INLONG-226)] Add Windows startup scripts
+ - [[INLONG-227](https://issues.apache.org/jira/browse/INLONG-227)] remove build guide in docker-build readme
+ - [[INLONG-232](https://issues.apache.org/jira/browse/INLONG-232)] TubeBroker#register2Master, reconnect and wait
+ - [[INLONG-234](https://issues.apache.org/jira/browse/INLONG-234)] Add .asf.yaml to change notifications
+ - [[INLONG-235](https://issues.apache.org/jira/browse/INLONG-235)] Add code coverage supporting for pull request created.
+ - [[INLONG-237](https://issues.apache.org/jira/browse/INLONG-237)] add maven module build for docker image
+
+### BUG FIXES:
+ - [[INLONG-47](https://issues.apache.org/jira/browse/INLONG-47)] Fix some typos
+ - [[INLONG-102](https://issues.apache.org/jira/browse/INLONG-102)] Fix question [INLONG-101] [Optimize code]
+ - [[INLONG-121](https://issues.apache.org/jira/browse/INLONG-121)] Fix compilation alarm
+ - [[INLONG-139](https://issues.apache.org/jira/browse/INLONG-139)] a bug in the equals method of the TubeClientConfig class
+ - [[INLONG-157](https://issues.apache.org/jira/browse/INLONG-157)] Optimize Broker disk anomaly check
+ - [[INLONG-158](https://issues.apache.org/jira/browse/INLONG-158)] nextWithAuthInfo2B status should be managed independently according to Broker
+ - [[INLONG-159](https://issues.apache.org/jira/browse/INLONG-159)] Fix some typos
+ - [[INLONG-165](https://issues.apache.org/jira/browse/INLONG-165)] Remove unnecessary fiiles
+ - [[INLONG-205](https://issues.apache.org/jira/browse/INLONG-205)] Duplicate dependency of jetty in tuber-server pom file
+ - [[INLONG-206](https://issues.apache.org/jira/browse/INLONG-206)] There are some residual files after executed unit tests
+ - [[INLONG-210](https://issues.apache.org/jira/browse/INLONG-210)] Add log4j properties file for unit tests
+ - [[INLONG-217](https://issues.apache.org/jira/browse/INLONG-217)] UPdate the je download path
+ - [[INLONG-218](https://issues.apache.org/jira/browse/INLONG-218)] build failed: Too many files with unapproved license
+ - [[INLONG-230](https://issues.apache.org/jira/browse/INLONG-230)] TubeMQ run mvn test failed with openjdk version 13.0.2
+ - [[INLONG-236](https://issues.apache.org/jira/browse/INLONG-236)] Can't get dependencies from the maven repository
+ - [[INLONG-253](https://issues.apache.org/jira/browse/INLONG-253)] tube-consumer fetch-worker cpu used too high
+ - [[INLONG-254](https://issues.apache.org/jira/browse/INLONG-254)] support using different mapping port for standalone mode
+ - [[INLONG-265](https://issues.apache.org/jira/browse/INLONG-265)] Unexpected broker disappearance in broker list after updating default broker metadata
+  

--- a/download/release-0.6.0.md
+++ b/download/release-0.6.0.md
@@ -1,0 +1,39 @@
+---
+title: 0.6.0
+---
+
+# Download the InLong releases
+
+Use the links below to download the Apache InLong from one of our mirrors.
+
+## InLong
+| Date | Version| Comment | Downloads |
+|:---:|:--:|:--:|:--:|
+| October. 21th, 2020 | 0.6.0 | Source | [[SRC](https://archive.apache.org/dist/incubator/tubemq/0.6.0-incubating/apache-tubemq-0.6.0-incubating-src.tar.gz)]                 [[PGP](https://archive.apache.org/dist/incubator/tubemq/0.6.0-incubating/apache-tubemq-0.6.0-incubating-src.tar.gz.asc)]             [[SHA512](https://archive.apache.org/dist/incubator/tubemq/0.6.0-incubating/apache-tubemq-0.6.0-incubating-src.tar.gz.sha512)] |
+| |                       | Client | [[TAR](https://archive.apache.org/dist/incubator/tubemq/0.6.0-incubating/apache-tubemq-client-0.6.0-incubating-bin.tar.gz)]          [[PGP](https://archive.apache.org/dist/incubator/tubemq/0.6.0-incubating/apache-tubemq-client-0.6.0-incubating-bin.tar.gz.asc)]      [[SHA512](https://archive.apache.org/dist/incubator/tubemq/0.6.0-incubating/apache-tubemq-client-0.6.0-incubating-bin.tar.gz.sha512)] |
+| |                       | Server | [[TAR](https://archive.apache.org/dist/incubator/tubemq/0.6.0-incubating/apache-tubemq-server-0.6.0-incubating-bin.tar.gz)]          [[PGP](https://archive.apache.org/dist/incubator/tubemq/0.6.0-incubating/apache-tubemq-server-0.6.0-incubating-bin.tar.gz.asc)]      [[SHA512](https://archive.apache.org/dist/incubator/tubemq/0.6.0-incubating/apache-tubemq-server-0.6.0-incubating-bin.tar.gz.sha512)] |
+
+
+## Release Notes
+
+### New Features
+- [[INLONG-319](https://issues.apache.org/jira/browse/INLONG-319)] In the pull mode, consumers support the  suspension of consumption for a certain partition
+- [[INLONG-3](https://issues.apache.org/jira/browse/INLONG-3)] C++ SDK support in TubeMQ
+
+### IMPROVEMENTS
+- [[INLONG-311](https://issues.apache.org/jira/browse/INLONG-311)] Feedback more production information
+- [[INLONG-312](https://issues.apache.org/jira/browse/INLONG-312)] Feedback more consumption information
+- [[INLONG-325](https://issues.apache.org/jira/browse/INLONG-325)] Add 406 ~ 408 error code to pullSelect call
+- [[INLONG-345](https://issues.apache.org/jira/browse/INLONG-345)] Optimize the call logic of getMessage() in Pull mode
+- [[INLONG-352](https://issues.apache.org/jira/browse/INLONG-352)] Set the parameters of the example at startup
+- [[INLONG-353](https://issues.apache.org/jira/browse/INLONG-353)] Update LICENSE about C/C++ SDK's code reference
+- [[INLONG-356](https://issues.apache.org/jira/browse/INLONG-356)] C++ SDK Codec decode add requestid
+- [[INLONG-327](https://issues.apache.org/jira/browse/INLONG-327)] Fix the concurrency problem in the example
+
+### BUG FIXES
+- [[INLONG-316](https://issues.apache.org/jira/browse/INLONG-316)] Where the port the port is aleady used, the  process throw the exception, but not exit
+- [[INLONG-317](https://issues.apache.org/jira/browse/INLONG-317)] The Store Manager throws java.lang.NullPointerException
+- [[INLONG-320](https://issues.apache.org/jira/browse/INLONG-320)] Request for static web contents would get responses with no content
+- [[INLONG-354](https://issues.apache.org/jira/browse/INLONG-354)] Found a dns translate bug in C/C++ sdk
+- [[INLONG-306](https://issues.apache.org/jira/browse/INLONG-306)] Raise Nullpointer Exception when create tubemq instance
+- [[INLONG-359](https://issues.apache.org/jira/browse/INLONG-359)] TubeMQ consume speed dropped to 0 in some partitions, it is a very serious bug  Blocker

--- a/download/release-0.7.0.md
+++ b/download/release-0.7.0.md
@@ -1,0 +1,56 @@
+---
+title: 0.7.0
+---
+
+# Download the InLong releases
+
+Use the links below to download the Apache InLong from one of our mirrors.
+
+## InLong
+| Date | Version| Comment | Downloads |
+|:---:|:--:|:--:|:--:|
+| December. 4th, 2020 | 0.7.0 | Source | [[SRC](https://archive.apache.org/dist/incubator/tubemq/0.7.0-incubating/apache-tubemq-0.7.0-incubating-src.tar.gz)]                 [[PGP](https://archive.apache.org/dist/incubator/tubemq/0.7.0-incubating/apache-tubemq-0.7.0-incubating-src.tar.gz.asc)]             [[SHA512](https://archive.apache.org/dist/incubator/tubemq/0.7.0-incubating/apache-tubemq-0.7.0-incubating-src.tar.gz.sha512)] |
+| |                       | Client | [[TAR](https://archive.apache.org/dist/incubator/tubemq/0.7.0-incubating/apache-tubemq-client-0.7.0-incubating-bin.tar.gz)]          [[PGP](https://archive.apache.org/dist/incubator/tubemq/0.7.0-incubating/apache-tubemq-client-0.7.0-incubating-bin.tar.gz.asc)]      [[SHA512](https://archive.apache.org/dist/incubator/tubemq/0.7.0-incubating/apache-tubemq-client-0.7.0-incubating-bin.tar.gz.sha512)] |
+| |                       | Server | [[TAR](https://archive.apache.org/dist/incubator/tubemq/0.7.0-incubating/apache-tubemq-server-0.7.0-incubating-bin.tar.gz)]          [[PGP](https://archive.apache.org/dist/incubator/tubemq/0.7.0-incubating/apache-tubemq-server-0.7.0-incubating-bin.tar.gz.asc)]      [[SHA512](https://archive.apache.org/dist/incubator/tubemq/0.7.0-incubating/apache-tubemq-server-0.7.0-incubating-bin.tar.gz.sha512)] |
+
+
+## Release Notes
+
+### New Features:
+
+| JIRA  | Summary  | Priority |
+| :---- | :------- | :------- |
+| [INLONG-162](https://issues.apache.org/jira/browse/INLONG-162) | Python SDK support in TubeMQ | High |
+| [INLONG-336](https://issues.apache.org/jira/browse/INLONG-336) | Propose web portal to manage tube cluster Phase-I | Major |
+| [INLONG-390](https://issues.apache.org/jira/browse/INLONG-390)   | support build C++ SDK with docker image | Normal |
+
+### IMPROVEMENTS:
+
+| JIRA  | Summary  | Priority |
+| :---- | :------- | :------- |
+| [INLONG-369](https://issues.apache.org/jira/browse/INLONG-369) | hope to add an option in the compilation script (like `make lib` etc...)                 | Major    |
+| [INLONG-373](https://issues.apache.org/jira/browse/INLONG-373) | Reduce the redundant code of Utils::Split functions             | Major    |
+| [INLONG-374](https://issues.apache.org/jira/browse/INLONG-374) | Adjust some coding style issues     | Major    |
+| [INLONG-375](https://issues.apache.org/jira/browse/INLONG-375) | Add a section to the README file about how to compile the project| Major    |
+| [INLONG-385](https://issues.apache.org/jira/browse/INLONG-385) | update docker images     | Major    |
+| [INLONG-393](https://issues.apache.org/jira/browse/INLONG-393) | Optimize the mapping code of WEB API     | Major    |
+| [INLONG-406](https://issues.apache.org/jira/browse/INLONG-406) | test_consumer.py works for both Python 2 and 3   | Minor |
+| [INLONG-410](https://issues.apache.org/jira/browse/INLONG-410) | install python package and simplify test_consumer.py    | Major    |
+| [INLONG-416](https://issues.apache.org/jira/browse/INLONG-416) | support consume from specified position   | Major    |
+| [INLONG-417](https://issues.apache.org/jira/browse/INLONG-417) | C++ Client support parse message from binary data for Python SDK    | Major    |
+| [INLONG-419](https://issues.apache.org/jira/browse/INLONG-419) | SetMaxPartCheckPeriodMs() negative number, getMessage() still  | Major    |
+
+### BUG FIXES:
+
+| JIRA                                                         | Summary                                                      | Priority |
+| :----------------------------------------------------------- | :----------------------------------------------------------- | :------- |
+| [INLONG-365](https://issues.apache.org/jira/browse/INLONG-365) | Whether the consumption setting is wrong after the processRequest exception | Major    |
+| [INLONG-370](https://issues.apache.org/jira/browse/INLONG-370) | Calling GetCurConsumedInfo API always returns failure      | Major    |
+| [INLONG-376](https://issues.apache.org/jira/browse/INLONG-376) | Move pullrequests_status notifications commits mail list | Major    |
+| [INLONG-366](https://issues.apache.org/jira/browse/INLONG-366) | Found a nullpointerexception bug in broker | Normal |
+| [INLONG-379](https://issues.apache.org/jira/browse/INLONG-379) | Modify the memory cache size default to 3M | Normal |
+| [INLONG-380](https://issues.apache.org/jira/browse/INLONG-380) | Cpp client link error when gcc optimization is disabled   | Major    |
+| [INLONG-405](https://issues.apache.org/jira/browse/INLONG-405) | python sdk install files lack of the whole cpp configuration | Major |
+| [INLONG-401](https://issues.apache.org/jira/browse/INLONG-401) | python sdk readme bug | Minor |
+| [INLONG-407](https://issues.apache.org/jira/browse/INLONG-407) | Fix some content in README.md | Trivial |
+| [INLONG-418](https://issues.apache.org/jira/browse/INLONG-418) | C++ SDK function SetMaxPartCheckPeriodMs() can't work | Major |

--- a/download/release-0.8.0.md
+++ b/download/release-0.8.0.md
@@ -1,0 +1,102 @@
+---
+title: 0.8.0
+---
+
+# Download the InLong releases
+
+Use the links below to download the Apache InLong from one of our mirrors.
+
+## InLong
+| Date | Version| Comment | Downloads |
+|:---:|:--:|:--:|:--:|
+| March. 4th, 2021 | 0.8.0 | Source | [[SRC](https://archive.apache.org/dist/incubator/tubemq/0.8.0-incubating/apache-tubemq-0.8.0-incubating-src.tar.gz)]                 [[PGP](https://archive.apache.org/dist/incubator/tubemq/0.8.0-incubating/apache-tubemq-0.8.0-incubating-src.tar.gz.asc)]             [[SHA512](https://archive.apache.org/dist/incubator/tubemq/0.8.0-incubating/apache-tubemq-0.8.0-incubating-src.tar.gz.sha512)] |
+| |                       | Client | [[TAR](https://archive.apache.org/dist/incubator/tubemq/0.8.0-incubating/apache-tubemq-client-0.8.0-incubating-bin.tar.gz)]          [[PGP](https://archive.apache.org/dist/incubator/tubemq/0.8.0-incubating/apache-tubemq-client-0.8.0-incubating-bin.tar.gz.asc)]      [[SHA512](https://archive.apache.org/dist/incubator/tubemq/0.8.0-incubating/apache-tubemq-client-0.8.0-incubating-bin.tar.gz.sha512)] |
+| |                       | Server | [[TAR](https://archive.apache.org/dist/incubator/tubemq/0.8.0-incubating/apache-tubemq-server-0.8.0-incubating-bin.tar.gz)]          [[PGP](https://archive.apache.org/dist/incubator/tubemq/0.8.0-incubating/apache-tubemq-server-0.8.0-incubating-bin.tar.gz.asc)]      [[SHA512](https://archive.apache.org/dist/incubator/tubemq/0.8.0-incubating/apache-tubemq-server-0.8.0-incubating-bin.tar.gz.sha512)] |
+
+
+## Release Notes
+
+### IMPROVEMENTS:
+| JIRA  | Summary  | Priority |
+| :---- | :------- | :------- |
+| [INLONG-430](https://issues.apache.org/jira/browse/INLONG-430) | Optimizing the implementation of HTTP API for broke  | Major |
+| [INLONG-445](https://issues.apache.org/jira/browse/INLONG-445) | Adjust the status check default sleep interval of pullConsumeReadyChkSliceMs  | Major |
+| [INLONG-448](https://issues.apache.org/jira/browse/INLONG-448) | Add Committer and PPMC operation process  | Major |
+| [INLONG-449](https://issues.apache.org/jira/browse/INLONG-449) | Adjust Example implementation  | Major |
+| [INLONG-452](https://issues.apache.org/jira/browse/INLONG-452) | Optimize rebalance performance | Major |
+| [INLONG-467](https://issues.apache.org/jira/browse/INLONG-467) | Add WEB APIs of Master and Broker | Major |
+| [INLONG-489](https://issues.apache.org/jira/browse/INLONG-489) | Add the maximum message length parameter setting | Major |
+| [INLONG-495](https://issues.apache.org/jira/browse/INLONG-495) | Code implementation adjustment based on SpotBugs check | Major |
+| [INLONG-511](https://issues.apache.org/jira/browse/INLONG-511) | Replace the conditional operator (?:) with mid()  | Major |
+| [INLONG-512](https://issues.apache.org/jira/browse/INLONG-512) | Add package length control based on Topic  | Major |
+| [INLONG-515](https://issues.apache.org/jira/browse/INLONG-515) | Add cluster Topic view web api  | Major |
+
+### BUG FIXES:
+| JIRA  | Summary  | Priority |
+| :---- | :------- | :------- |
+| [INLONG-437](https://issues.apache.org/jira/browse/INLONG-437) | Fix tubemq table source sink factory instance creating problem | Major |
+| [INLONG-441](https://issues.apache.org/jira/browse/INLONG-441) | An error occurred when using the Tubemq class to create a sink table | Major |
+| [INLONG-442](https://issues.apache.org/jira/browse/INLONG-442) | Modifying the jvm parameters when the broker starts does not take effect  | Major    |
+| [INLONG-443](https://issues.apache.org/jira/browse/INLONG-443) | TubemqSourceFunction class prints too many logs problem | Major |
+| [INLONG-446](https://issues.apache.org/jira/browse/INLONG-446) | Small bugs fix that do not affect the main logics | Major |
+| [INLONG-450](https://issues.apache.org/jira/browse/INLONG-450) | TubeClientException: Generate producer id failed  | Major |
+| [INLONG-453](https://issues.apache.org/jira/browse/INLONG-453) | TubemqSourceFunction class prints too many logs problem | Major |
+| [INLONG-506](https://issues.apache.org/jira/browse/INLONG-506) | cmakelist error | Major |
+| [INLONG-510](https://issues.apache.org/jira/browse/INLONG-510) | Found a bug in MessageProducerExample class | Major |
+| [INLONG-518](https://issues.apache.org/jira/browse/INLONG-518) | fix parameter pass error | Major |
+| [INLONG-526](https://issues.apache.org/jira/browse/INLONG-526) | Adjust the packaging script and version check list, remove the "-WIP" tag | Major |
+| [INLONG-555](https://issues.apache.org/jira/browse/INLONG-555) | short session data can only be written to a specific partition | Major |
+| [INLONG-556](https://issues.apache.org/jira/browse/INLONG-556) | Index value is bigger than the actual number of records | Low |
+
+
+### TASK:
+| JIRA | Summary | Priority |
+|:---- |:---- | :--- |
+| [INLONG-505](https://issues.apache.org/jira/browse/INLONG-505) | Remove the "WIP" label of the DISCLAIMER file  | Major |
+| [INLONG-543](https://issues.apache.org/jira/browse/INLONG-543) | Modify the LICENSE statement of multiple files and others  | Major |
+| [INLONG-557](https://issues.apache.org/jira/browse/INLONG-557) | Handle the issues mentioned in the 0.8.0-RC2 review  | Major |
+| [INLONG-562](https://issues.apache.org/jira/browse/INLONG-562) | Update project contents according to the 0.8.0-RC3 review  | Major |
+
+### SUB-TASK:
+| JIRA  | Summary  | Priority |
+| :---- | :------- | :------- |
+| [INLONG-428](https://issues.apache.org/jira/browse/INLONG-433) | Bumped version to 0.8.0-SNAPSHOT | Major |
+| [INLONG-433](https://issues.apache.org/jira/browse/INLONG-433) | add tubemq perf-consumer/producer scripts | Major |
+| [INLONG-434](https://issues.apache.org/jira/browse/INLONG-434) | Adjust Broker API mapping | Major |
+| [INLONG-435](https://issues.apache.org/jira/browse/INLONG-435) | Create Web field Mapping | Major |
+| [INLONG-436](https://issues.apache.org/jira/browse/INLONG-436) | Adjust Broker's HTTP API implementation | Major |
+| [INLONG-439](https://issues.apache.org/jira/browse/INLONG-439) | Add Cli field Scheme definition | Major |
+| [INLONG-440](https://issues.apache.org/jira/browse/INLONG-440) | Add feature package tube-manager to zip  | Major |
+| [INLONG-444](https://issues.apache.org/jira/browse/INLONG-444) | Add consume and produce Cli commands | Major |
+| [INLONG-447](https://issues.apache.org/jira/browse/INLONG-447) | Add Broker-Admin Cli | Major |
+| [INLONG-451](https://issues.apache.org/jira/browse/INLONG-451) | Replace ConsumeTupleInfo with Tuple2  | Major    |
+| [INLONG-457](https://issues.apache.org/jira/browse/INLONG-457) | There is no need to return StringBuilder in Master.java | Major |
+| [INLONG-463](https://issues.apache.org/jira/browse/INLONG-463) | Adjust Master rebalance process implementation  | Major |
+| [INLONG-464](https://issues.apache.org/jira/browse/INLONG-464) | Add parameter rebalanceParallel in master.ini | Major |
+| [INLONG-470](https://issues.apache.org/jira/browse/INLONG-470) | Add query API of TopicName and BrokerId collection  | Major |
+| [INLONG-471](https://issues.apache.org/jira/browse/INLONG-471) | Add query API Introduction of TopicName and BrokerId collection | Major |
+| [INLONG-472](https://issues.apache.org/jira/browse/INLONG-472) | Adjust Broker's AbstractWebHandler class implementation  | Major |
+| [INLONG-475](https://issues.apache.org/jira/browse/INLONG-475) | add the offset clone api of the consume group  | Major |
+| [INLONG-482](https://issues.apache.org/jira/browse/INLONG-482) | Add offset query api  | Major |
+| [INLONG-484](https://issues.apache.org/jira/browse/INLONG-484) | Add query API for topic publication information  | Major |
+| [INLONG-485](https://issues.apache.org/jira/browse/INLONG-485) | Add the batch setting API of consume group offset  | Major |
+| [INLONG-486](https://issues.apache.org/jira/browse/INLONG-486) | Add the delete API of consumer group offset  | Major |
+| [INLONG-494](https://issues.apache.org/jira/browse/INLONG-494) | Update API interface instruction document | Major |
+| [INLONG-499](https://issues.apache.org/jira/browse/INLONG-499) | Add configure store  | Major |
+| [INLONG-500](https://issues.apache.org/jira/browse/INLONG-500) | Add setting operate API  | Major |
+| [INLONG-501](https://issues.apache.org/jira/browse/INLONG-501) | Adjust max message size check logic  | Major |
+| [INLONG-502](https://issues.apache.org/jira/browse/INLONG-502) | Add setting API interface document  | Major |
+| [INLONG-504](https://issues.apache.org/jira/browse/INLONG-504) | Adjust the WebMethodMapper class interfaces  | Major |
+| [INLONG-508](https://issues.apache.org/jira/browse/INLONG-508) | Optimize Broker's PB parameter check processing logic  | Major |
+| [INLONG-509](https://issues.apache.org/jira/browse/INLONG-509) | Adjust the packet length check when data is loaded  | Major |
+| [INLONG-522](https://issues.apache.org/jira/browse/INLONG-522) | Add admin_query_cluster_topic_view API document  | Major |
+| [INLONG-544](https://issues.apache.org/jira/browse/INLONG-544) | Adjust the LICENSE statement in the client.conf files of Python and C/C++ SDK | Major |
+| [INLONG-546](https://issues.apache.org/jira/browse/INLONG-546) | Restore the original license header of the referenced external source files | Major |
+| [INLONG-547](https://issues.apache.org/jira/browse/INLONG-547) | Recode the implementation of the *Startup.java classes in the Tool package | Major |
+| [INLONG-548](https://issues.apache.org/jira/browse/INLONG-548) | Handle the LICENSE authorization of font files in the resources | Major |
+| [INLONG-549](https://issues.apache.org/jira/browse/INLONG-549) | Handling the problem of compilation failure | Major |
+| [INLONG-550](https://issues.apache.org/jira/browse/INLONG-550) | Adjust LICENSE file content | Major |
+| [INLONG-551](https://issues.apache.org/jira/browse/INLONG-551) | Adjust NOTICE file content | Major |
+| [INLONG-558](https://issues.apache.org/jira/browse/INLONG-558) | Adjust the LICENSE of the file header | Major |
+| [INLONG-559](https://issues.apache.org/jira/browse/INLONG-559) | Update the LICENSE file according to the 0.8.0-RC2 review | Major |
+| [INLONG-560](https://issues.apache.org/jira/browse/INLONG-560) | Remove unprepared modules | Major |

--- a/download/release-0.9.0.md
+++ b/download/release-0.9.0.md
@@ -1,0 +1,104 @@
+---
+title: 0.9.0
+---
+
+# Download the InLong releases
+
+Use the links below to download the Apache InLong from one of our mirrors.
+
+## InLong
+| Date | Version| Comment | Downloads |
+|:---:|:--:|:--:|:--:|
+| July 11, 2021 | 0.9.0 | Source | [[SRC](https://archive.apache.org/dist/incubator/inlong/0.9.0-incubating/apache-inlong-0.9.0-incubating-src.tar.gz)]                 [[ASC](https://archive.apache.org/dist/incubator/inlong/0.9.0-incubating/apache-inlong-0.9.0-incubating-src.tar.gz.asc)]             [[SHA512](https://archive.apache.org/dist/incubator/inlong/0.9.0-incubating/apache-inlong-0.9.0-incubating-src.tar.gz.sha512)] |
+
+
+### Release Integrity
+   You must [verify](https://www.apache.org/info/verification.html) the integrity of the downloaded files. We provide OpenPGP signatures for every release file. This signature should be matched against the [KEYS](https://downloads.apache.org/incubator/inlong/KEYS) file which contains the OpenPGP keys of InLong's Release Managers. We also provide <code>SHA-512</code> checksums for every release file. After you download the file, you should calculate a checksum for your download, and make sure it is the same as ours.
+
+
+## Release Notes
+
+### IMPROVEMENTS:
+| JIRA  | Summary  | Priority |
+| :---- | :------- | :------- |
+| [INLONG-594](https://issues.apache.org/jira/browse/INLONG-594) | Trpc-go  tube sdk strongly rely on local config  | Major |
+| [INLONG-616](https://issues.apache.org/jira/browse/INLONG-616) | Adjust the content in .asf.yaml according to the new project name  | Major |
+| [INLONG-651](https://issues.apache.org/jira/browse/INLONG-651) | Refine the tubemq-client-cpp build description  | Major |
+| [INLONG-655](https://issues.apache.org/jira/browse/INLONG-655) | add dependency in tube-manager  | Major |
+| [INLONG-656](https://issues.apache.org/jira/browse/INLONG-656) | fix tubemanager start.sh  | Major |
+| [INLONG-657](https://issues.apache.org/jira/browse/INLONG-657) | remove some test cases in agent  | Major |
+| [INLONG-659](https://issues.apache.org/jira/browse/INLONG-659) | fix unit test in agent  | Major |
+| [INLONG-666](https://issues.apache.org/jira/browse/INLONG-666) | change tar name in agent  | Major |
+| [INLONG-697](https://issues.apache.org/jira/browse/INLONG-697) | fix decode error in proxySdk  | Major |
+| [INLONG-705](https://issues.apache.org/jira/browse/INLONG-705) | add stop.sh in dataproxy  | Major |
+| [INLONG-743](https://issues.apache.org/jira/browse/INLONG-743) | Adjust the rat check setting of the pom.xml  | Major |
+
+### BUG FIXES:
+| JIRA  | Summary  | Priority |
+| :---- | :------- | :------- |
+| [INLONG-577](https://issues.apache.org/jira/browse/INLONG-577) | reload status output and topic config output mismatch | Major |
+| [INLONG-612](https://issues.apache.org/jira/browse/INLONG-612) | Restful api "admin_snapshot_message" is not compatible with the old version | Major |
+| [INLONG-638](https://issues.apache.org/jira/browse/INLONG-638) | Issues About Disk Error recovery | Major |
+| [INLONG-688](https://issues.apache.org/jira/browse/INLONG-688) | change additionstr to additionAtr in agent | Major |
+| [INLONG-703](https://issues.apache.org/jira/browse/INLONG-703) | Query after adding a consumer group policy and report a null error | Major |
+| [INLONG-724](https://issues.apache.org/jira/browse/INLONG-724) | Encountered a symbol not found error when compiling | Major |
+
+
+### TASK:
+| JIRA | Summary | Priority |
+|:---- |:---- | :--- |
+| [INLONG-613](https://issues.apache.org/jira/browse/INLONG-613) | Adjust the project codes according to the renaming requirements  | Major |
+
+### SUB-TASK:
+| JIRA  | Summary  | Priority |
+| :---- | :------- | :------- |
+| [INLONG-519](https://issues.apache.org/jira/browse/INLONG-519) | Bumped version to 0.9.0-SNAPSHOT | Major |
+| [INLONG-565](https://issues.apache.org/jira/browse/INLONG-565) | Replace simple scripts and code implementation | Major |
+| [INLONG-571](https://issues.apache.org/jira/browse/INLONG-571) | Adjust WebOtherInfoHandler class implementation | Major |
+| [INLONG-573](https://issues.apache.org/jira/browse/INLONG-573) | Adjust WebAdminFlowRuleHandler class implementation | Major |
+| [INLONG-574](https://issues.apache.org/jira/browse/INLONG-574) | Adjust WebAdminGroupCtrlHandler class implementation | Major |
+| [INLONG-632](https://issues.apache.org/jira/browse/INLONG-632) | Add inlong-manager subdirectory | Major |
+| [INLONG-633](https://issues.apache.org/jira/browse/INLONG-633) | Add inlong-sort subdirectory | Major |
+| [INLONG-634](https://issues.apache.org/jira/browse/INLONG-634) | Add inlong-tubemq subdirectory | Major |
+| [INLONG-635](https://issues.apache.org/jira/browse/INLONG-635) | Add inlong-dataproxy subdirectory | Major |
+| [INLONG-636](https://issues.apache.org/jira/browse/INLONG-636) | Add inlong-agent subdirectory | Major |
+| [INLONG-640](https://issues.apache.org/jira/browse/INLONG-640) | Adjust the main frame of the InLong project | Major |
+| [INLONG-641](https://issues.apache.org/jira/browse/INLONG-641) | Add inlong-common module | Major |
+| [INLONG-642](https://issues.apache.org/jira/browse/INLONG-642) | Add inlong-website subdirectory | Major |
+| [INLONG-643](https://issues.apache.org/jira/browse/INLONG-643) | Add inlong-dataproxy-sdk subdirectory | Major |
+| [INLONG-644](https://issues.apache.org/jira/browse/INLONG-644) | Remove "/dist" from .gitignore and add subdirectory dist in inlong-sort | Major |
+| [INLONG-646](https://issues.apache.org/jira/browse/INLONG-646) | Remove time related unit tests until timezone is configurable in inlong-sort | Major |
+| [INLONG-647](https://issues.apache.org/jira/browse/INLONG-647) | Adjust the introduction content of the README.md | Major |
+| [INLONG-648](https://issues.apache.org/jira/browse/INLONG-648) | Change initial version of inlong-sort to 0.9.0-incubating-SNAPSHOT | Major |
+| [INLONG-649](https://issues.apache.org/jira/browse/INLONG-649) | Modify the suffix of the docs/zh-cn/download/release-0.8.0.md file | Major |
+| [INLONG-650](https://issues.apache.org/jira/browse/INLONG-650) | Adjust .asf.yaml's label | Major |
+| [INLONG-654](https://issues.apache.org/jira/browse/INLONG-654) | Adjust the link in ReadMe.md according to the latest document | Major |
+| [INLONG-658](https://issues.apache.org/jira/browse/INLONG-658) | modify the dependency of inlong-manager | Major |
+| [INLONG-663](https://issues.apache.org/jira/browse/INLONG-663) | modify the tar package name of inlong-manager | Major |
+| [INLONG-667](https://issues.apache.org/jira/browse/INLONG-667) | rename tar in agent | Major |
+| [INLONG-673](https://issues.apache.org/jira/browse/INLONG-673) | add tube cluster id in inlong-manager | Major |
+| [INLONG-674](https://issues.apache.org/jira/browse/INLONG-674) | adjust HiveSinkInfo in inlong-manager | Major |
+| [INLONG-675](https://issues.apache.org/jira/browse/INLONG-675) | modify the npm script of inlong-website | Major |
+| [INLONG-676](https://issues.apache.org/jira/browse/INLONG-676) | modify manager-web to manager-api in inlong-manager module | Major |
+| [INLONG-677](https://issues.apache.org/jira/browse/INLONG-677) | Support dt as built-in data time partition field in inlong-sort | Major |
+| [INLONG-681](https://issues.apache.org/jira/browse/INLONG-681) | modify assembly in agent proxy tubemanager | Major |
+| [INLONG-687](https://issues.apache.org/jira/browse/INLONG-687) | set schemaName to m0_day when save business in inlong-manager | Major |
+| [INLONG-689](https://issues.apache.org/jira/browse/INLONG-689) | add sort app name | Major |
+| [INLONG-691](https://issues.apache.org/jira/browse/INLONG-691) | update properties and scripts for inlong-manager | Major |
+| [INLONG-692](https://issues.apache.org/jira/browse/INLONG-692) | remove hive cluster entity in inlong-manager | Major |
+| [INLONG-693](https://issues.apache.org/jira/browse/INLONG-693) | change data type to tdmsg | Major |
+| [INLONG-694](https://issues.apache.org/jira/browse/INLONG-694) | Add retry mechanism for creating tube consumer group | Major |
+| [INLONG-695](https://issues.apache.org/jira/browse/INLONG-695) | update getConfig API in inlong-manager | Major |
+| [INLONG-696](https://issues.apache.org/jira/browse/INLONG-696) | modify the status of the entities after approval | Major |
+| [INLONG-699](https://issues.apache.org/jira/browse/INLONG-699) | Fix serialization issue of DeserializationInfo 's subType in inlong-sort | Major |
+| [INLONG-700](https://issues.apache.org/jira/browse/INLONG-700) | Optimize dependencies in inlong-sort | Major |
+| [INLONG-701](https://issues.apache.org/jira/browse/INLONG-701) | Update create resource workflow definition | Major |
+| [INLONG-702](https://issues.apache.org/jira/browse/INLONG-702) | sort config field spillter | Major |
+| [INLONG-706](https://issues.apache.org/jira/browse/INLONG-706) | Add 0.9.0 version release modification to CHANGES.md | Major |
+| [INLONG-709](https://issues.apache.org/jira/browse/INLONG-709) | Adjust the version information of all pom.xml to 0.9.0-incubating | Major |
+| [INLONG-712](https://issues.apache.org/jira/browse/INLONG-712) | adjust partition info for hive sink | Major |
+| [INLONG-713](https://issues.apache.org/jira/browse/INLONG-713) | add partition filed when create hive table | Major |
+| [INLONG-714](https://issues.apache.org/jira/browse/INLONG-714) | Enable checkpointing in inlong-sort | Major |
+| [INLONG-715](https://issues.apache.org/jira/browse/INLONG-715) | Make shouldRollOnCheckpoint always return true in DefaultRollingPolicy in inlong-sort | Major |
+| [INLONG-716](https://issues.apache.org/jira/browse/INLONG-716) | set terminated symbol when create hive table | Major |
+| [INLONG-717](https://issues.apache.org/jira/browse/INLONG-717) | Declare the 3rd party Catagory x LICENSE components in use | Major |


### PR DESCRIPTION
Fixes #apache/incubator-inlong#1634

where *XYZ* should be replaced by the actual issue number.

### Motivation

*Explain here the context, and why you're making that change. What is the problem you're trying to solve.*

### Modifications

*Describe the modifications you've done.*

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
