### PR TITLE
[INLONG-1635] Migrate development documentation

### DIFF
--- a/development/how-to-become-a-committer.md
+++ b/development/how-to-become-a-committer.md
@@ -1,0 +1,38 @@
+---
+title: How to Become a Committer
+sidebar_position: 4
+---
+
+# 如何成为Apache InLong Committer 和 PPMC
+
+<font color="#dd0000" size="4">TODO: This page needs to be translated into English. If you are interested, just do it.</font>
+
+> Apache InLong是完全按照Apache的规则来构建社区的，Apache Committer是ASF（Apache软件基金会）中用来表示提交特定项目的人的术语，
+Apache InLong Committer拥有InLong代码库的写权限，可以合并PR，任何人只要为社区做出了足够的贡献并获取到足够的信任就可以成为Apache InLong Committer。
+
+任何人只要对InLong项目做了贡献，那你就是官方承认的InLong项目的Contributor了，从Contributor成长为Committer并没有一个确切的标准，
+也没有任何预期的时间表，但是Committer的候选人一般都是长期活跃的贡献者，成为Committer并没有要求必须有巨大的架构改进贡献，
+或者多少行的代码贡献，贡献代码、贡献文档、参与邮件列表的讨论、帮助回答问题等等都提升自己影响力的方式。
+
+潜在贡献清单（无特定顺序）：
+- 提交自己发现的Bug、特性、改进到issue
+- 更新官方文档使项目的文档是最近的、撰写InLong的最佳实践、特性剖析的各种对用户有用的文档
+- 执行测试并报告测试结果，性能测试与其他Agent、MQ等模块的性能对比测试等
+- 发布版本时，积极参与投票
+- 参与邮件列表中的讨论，一般会有以[DISCUSS]开头的邮件
+- 回答用户或开发人员在邮件列表中的提问
+- 审查(Review)其他人的工作（包括代码和非代码）并发表你自己的建议
+- 对JIRA上的issue进行审查，维护issue为最新状态，比如：关闭过时的issue、更改issue的错误信息等
+- 指导新加入的贡献者，熟悉社区流程
+- 发表关于InLong的演讲和博客，并将这些添加到InLong的官方网站
+- 有利于InLong社区发展的任何贡献
+- ......
+
+更多可以参考：[ASF官方文档](https://community.apache.org/contributors/)
+
+并不是每个人都能完成这个清单上的所有（甚至任何）项目。如果你想用其他方式来做贡献，那就去做吧（并把它们添加到列表中）。
+愉快的举止和乐于奉献的精神是您对InLong项目产生积极影响所需要的全部。
+邀请您成为Committer是您与社区长期稳定互动的结果，是InLong社区对您的信任和认可。
+
+Committer有义务审查(Review)和合并(merge)其他人提交的PR，版本发布时测试和投票候选版本，参与特性设计方案的讨论以及其他类型的项目贡献。
+当你足够活跃且对社区的贡献比较大后，就可以晋升为InLong项目的PPMC成员。

--- a/development/how-to-commit.md
+++ b/development/how-to-commit.md
@@ -1,0 +1,82 @@
+---
+title: How to Commit
+sidebar_position: 2
+---
+
+# 如何提交代码
+
+<font color="#dd0000" size="4">TODO: This page needs to be translated into English. If you are interested, just do it.</font>
+
+## 0. 前言
+Apache InLong使用Github的Pull Request (PR)来接收贡献的代码，本文将详细介绍提交代码的详细流程。
+
+- InLong代码库：https://github.com/apache/incubator-inlong
+
+- InLong官网库：https://github.com/apache/incubator-inlong-website
+
+## 1. Fork仓库
+
+进入 [apache/incubator-inlong](https://github.com/apache/incubator-inlong) 的Github页面 ，点击右上角按钮 `Fork` 进行 Fork。
+
+## 2. 配置git和提交修改
+
+### 2.1 将代码克隆到本地
+```shell
+git clone https://github.com/<your_github_name>/incubator-inlong.git
+```
+clone完成后，origin会默认指向github上的远程fork地址。
+
+### 2.2 将 apache/incubator-inlong 添加为本地仓库的远程分支upstream
+```shell
+cd  incubator-inlong
+git remote add upstream https://github.com/apache/incubator-inlong.git
+```
+### 2.3 检查远程仓库设置
+```shell
+git remote -v
+origin    https://github.com/<your_github_name>/incubator-inlong.git (fetch)
+origin    https://github.com/<your_github_name>/incubator-inlong.git(push)
+upstream  https://github.com/apache/incubator-inlong.git (fetch)
+upstream  https://github.com/apache/incubator-inlong.git (push)
+```
+此时会有两个仓库：origin(自己的仓库)和upstream（官方的仓库）
+
+### 2.4 获取upstream仓库代码，并更新本地master分支代码为最新
+```shell
+git fetch upstream
+git pull upstream master
+```
+### 2.5 新建分支
+> 一般以issue id作为分支名，如：INLONG-123
+```shell
+git checkout -b INLONG-123
+```
+**确保分支`INLONG-123`是基于官方master分支的最新代码**
+
+分支创建完成后即可进行代码更改。
+
+### 2.6 提交代码到远程分支
+> commit 信息的格式必须与Issue标题保持一致且以`[issue id]`开头，即：`[INLONG-123] xxx`
+```shell
+git commit -a -m "[INLONG-123] xxx"
+git push origin INLONG-123
+```
+## 3. 创建PR
+### 3.1 打开自己的github仓库页面
+    `https://github.com/<your_github_name>/incubator-inlong`
+### 3.2. 切换分支
+    切换到提交的分支 `INLONG-123`
+### 3.3. 创建新PR
+    点击 `New pull request`或者`Compare & pull request`
+### 3.4. 点击`Create pull request`按钮进行创建PR
+    需要注意以下几点：
+      1. PR的标题必须以issue id开头，最好与commit信息保持一致
+      2. 可以填写部分描述信息也可以不填
+      3. 如果点击`Create pull request`后提示代码冲突，则请将`INLONG-123`分支的代码
+         与master分支同步一致后在进行提交
+
+## 4. Review代码
+创建完PR后，所有的人都可以Review代码，可能会与您讨论一些实现的细节，可能还需要你进一步修改。
+**一般该PR必须有2位以上的社区PPMC/Committer +1后，才可能正式合入官方代码库。**
+
+最后，恭喜您已经成为了InLong的官方贡献者了！

--- a/development/how-to-contribute.md
+++ b/development/how-to-contribute.md
@@ -1,0 +1,67 @@
+---
+title: How to Contribute
+sidebar_position: 1
+---
+
+# How to Contribute
+
+The Apache InLong(incubating) community welcomes contributions from anyone with a passion for distributed systems! InLong has many different opportunities for contributions -- write new examples/tutorials, add new user-facing libraries or participate on the documentation effort.
+
+We use a review-then-commit workflow in InLong for all contributions.
+
+**For larger contributions or those that affect multiple components:**
+
+1. **Engage**: We encourage you to work with the InLong community on the [JIRA](https://jira.apache.org/jira/browse/INLONG) and [developer’s mailing list](../contact.html) to identify good areas for contribution.
+2. **Design:** More complicated contributions will likely benefit from some early discussion in order to scope and design them well.
+
+**For all contributions:**
+
+1. **Code:** The you-know-what part.
+2. **Review:** Submit a pull request with your contribution to our [GitHub Repo](https://github.com/apache/incubator-inlong). Work with a committer to review and iterate on the code, if needed.
+3. **Commit:** Once at least 1 InLong committer has approved the pull request, a InLong committer will merge it into the master branch (and potentially backport to stable branches in case of bug fixes).
+
+We look forward to working with you!
+
+## Engage
+
+### Mailing list(s)
+
+We discuss design and implementation issues on the [dev@inlong.apache.org](mailto:dev@inlong.apache.org) mailing list, which is archived [here](https://lists.apache.org/list.html?dev@inlong.apache.org). Join by emailing [`dev-subscribe@inlong.apache.org`](mailto:dev-subscribe@inlong.apache.org).
+
+### JIRA
+
+We are using [JIRA](https://jira.apache.org/jira/browse/INLONG) as the issue tracking
+and project management tool, as well as a way to communicate among a very diverse and distributed set of contributors. To be able to gather feedback, avoid frustration, and avoid duplicated efforts all InLong related work are being tracked there.
+
+If you do not already have an JIRA account, sign up [here](https://jira.apache.org/jira/secure/Signup!default.jspa).
+
+If a quick [search](https://jira.apache.org/jira/projects/INLONG/issues) doesn’t turn up an existing JIRA issue for the work you want to contribute, create it. Please discuss your idea with a committer in JIRA or, alternatively, on the developer mailing list.
+
+If there’s an existing JIRA issue for your intended contribution, please comment about your intended work. Once the work is understood, a committer will assign the issue to you. If an issue is currently assigned, please check with the current assignee before reassigning.
+
+For moderate or large contributions, you should not start coding or writing a design document unless there is a corresponding JIRA issue assigned to you for that work. Any change requires an associated JIRA issue.
+
+## Design
+
+To avoid potential frustration during the code review cycle, we encourage you to clearly scope and design non-trivial contributions with the InLong community before you start coding.
+
+We are using "InLong Improvement Proposals" for managing major changes to InLong. The list of all proposals is maintained in the InLong wiki at [this page](https://cwiki.apache.org/confluence/display/INLONG/INLONG+Improvement+Proposals).
+
+## Commit (committers only)
+
+Once the code has been peer reviewed by a committer, the next step is for the committer to merge it into the Github repo.
+
+Pull requests should not be merged before the review has approved from at least 1 committer.
+
+For more about merging pull request, please refer to [this page](https://cwiki.apache.org/confluence/display/INLONG/Merging+Pull+Requests)
+
+## Website Contributor List
+We are very pleased to announce some contributors here. They have made a lot of contributions in the translation of InLong. Thanks again to the following participants.
+ - deepEvolution
+ - missy
+ - min.yang
+ - goson
+ - stillcoolme
+ - tboy
+ - viviel
+ - yuecai.liu

--- a/development/how-to-release.md
+++ b/development/how-to-release.md
@@ -1,0 +1,520 @@
+---
+title: How to Release
+sidebar_position: 6
+---
+
+# 如何发布版本
+
+<font color="#dd0000" size="4">TODO: This page needs to be translated into English. If you are interested, just do it.</font>
+
+> 本文主要介绍了Release Manager如何按照Apache的流程发布版本，
+
+## 0. 前言
+Source Release是Apache关注的重点，也是发布的必须内容；
+Binary Release是可选项，InLong可以选择是否发布二进制包到Apache仓库或者发布到Maven中央仓库。
+
+请参考以下链接，找到更多关于ASF的发布指南:
+
+[Apache Release Guide](https://incubator.apache.org/guides/releasemanagement.html)
+
+[Apache incubator 官网](https://incubator.apache.org/)
+
+## 1. 添加GPG KEY
+> 本章节主要参考：https://infra.apache.org/openpgp.html
+**该章节仅仅对第一次当该项目的Release Manager需要。**
+
+### 1.1 安装gpg
+详细的安装文档可以参考[官网](https://www.gnupg.org/download/index.html), Mac OS环境配置如下
+```shell
+$ brew install gpg
+$ gpg --version #检查版本，应该为2.x
+```
+### 1.2 生成gpg Key
+#### 需要注意以下几点：
+- 输入名字时最好与Apache中登记的Full name保持一致
+- 使用的邮箱应该是apache邮箱
+- 名字最好使用拼音或者英文，否则会出现乱码
+
+#### 根据提示，生成key
+```shell
+➜  ~ gpg --full-gen-key
+gpg (GnuPG) 2.2.20; Copyright (C) 2020 Free Software Foundation, Inc.
+This is free software: you are free to change and redistribute it.
+There is NO WARRANTY, to the extent permitted by law.
+
+Please select what kind of key you want:
+   (1) RSA and RSA (default)
+   (2) DSA and Elgamal
+   (3) DSA (sign only)
+   (4) RSA (sign only)
+  (14) Existing key from card
+Your selection? 1 # 这里输入1
+RSA keys may be between 1024 and 4096 bits long.
+What keysize do you want? (2048) 4096 # 这里输入4096
+Requested keysize is 4096 bits       
+Please specify how long the key should be valid.
+         0 = key does not expire
+      <n>  = key expires in n days
+      <n>w = key expires in n weeks
+      <n>m = key expires in n months
+      <n>y = key expires in n years
+Key is valid for? (0) 0 # 这里输入0
+Key does not expire at all
+Is this correct? (y/N) y # 这里输入y
+
+GnuPG needs to construct a user ID to identify your key.
+
+Real name: Guangxu Cheng # 这里输入你的名字
+Email address: gxcheng@apache.org # 这里输入你的邮箱
+Comment:                          # 这里输入一些注释，可以为空
+You selected this USER-ID:
+    "Guangxu Cheng <gxcheng@apache.org>"
+
+Change (N)ame, (C)omment, (E)mail or (O)kay/(Q)uit? O #这里输入O
+We need to generate a lot of random bytes. It is a good idea to perform
+some other action (type on the keyboard, move the mouse, utilize the
+disks) during the prime generation; this gives the random number
+generator a better chance to gain enough entropy.
+We need to generate a lot of random bytes. It is a good idea to perform
+some other action (type on the keyboard, move the mouse, utilize the
+disks) during the prime generation; this gives the random number
+generator a better chance to gain enough entropy.
+
+# 此时会弹出对话框，要求你为这个gpg输入密钥。
+┌──────────────────────────────────────────────────────┐
+│ Please enter this passphrase                         │
+│                                                      │
+│ Passphrase: _______________________________          │
+│                                                      │
+│       <OK>                              <Cancel>     │
+└──────────────────────────────────────────────────────┘
+#输入秘钥完毕后就创建好了。并会输出以下信息
+gpg: key 2DD587E7B10F3B1F marked as ultimately trusted
+gpg: revocation certificate stored as '/Users/cheng/.gnupg/openpgp-revocs.d/41936314E25F402D5F7D73152DD587E7B10F3B1F.rev'
+public and secret key created and signed.
+
+pub   rsa4096 2020-05-19 [SC]
+      41936314E25F402D5F7D73152DD587E7B10F3B1F
+uid                      Guangxu Cheng <gxcheng@apache.org>
+sub   rsa4096 2020-05-19 [E]
+```
+
+### 1.3 上传生成的key到公共服务器
+
+```shell
+➜  ~ gpg --list-keys                                                        
+-------------------------------
+pub   rsa4096 2020-05-18 [SC]
+      5931F8CFD04B37A325E4465D8C0D31C4149B3A87
+uid           [ultimate] Guangxu Cheng <gxcheng@apache.org>
+sub   rsa4096 2020-05-18 [E]
+
+# 通过key id发送public key到keyserver
+$ gpg --keyserver pgpkeys.mit.edu --send-key <key id>
+# 其中，pgpkeys.mit.edu为随意挑选的keyserver，keyserver列表为：https://sks-keyservers.net/status/，为相互之间是自动同步的，选任意一个都可以。
+```
+
+### 1.4 查看key是否创建成功
+通过下面的网址，使用邮箱查询上传成功没，大概需要一分钟才能查到，查询时候把 advance 下边的 show full-key hashes 勾上
+http://keys.gnupg.net
+
+查询结果如下：
+
+
+
+### 1.5 将你的gpg公钥加入KEYS文件
+
+> 这个步骤需要使用SVN
+
+DEV分支的svn库是 https://dist.apache.org/repos/dist/dev/incubator/inlong
+
+Release分支的SVN库是 https://dist.apache.org/repos/dist/release/incubator/inlong
+
+#### 1.5.1 在dev分支中添加公钥到KEYS，用于发布RC版本
+
+```shell
+➜  ~ svn co https://dist.apache.org/repos/dist/dev/incubator/inlong /tmp/inlong-dist-dev
+# 这个步骤比较慢，会把所有版本都拷贝下来，如果网断了，用svn cleanup删掉锁，重新执行一下，会断点续传
+➜  ~ cd inlong-dist-dev
+➜  inlong-dist-dev ~ (gpg --list-sigs YOUR_NAME@apache.org && gpg --export --armor YOUR_NAME@apache.org) >> KEYS # 追加你生成的KEY到文件KEYS中, 追加后最好检查一下是否正确
+➜  inlong-dist-dev ~ svn add .	# 如果之前存在KEYS文件，则不需要
+➜  inlong-dist-dev ~ svn ci -m "add gpg key for YOUR_NAME" # 接下来会要求输入用户名和密码，就用你的apache的用户名和密码。
+```
+
+#### 1.5.2 在release分支中添加公钥到KEYS，用于发布正式版本
+
+```shell
+➜  ~ svn co https://dist.apache.org/repos/dist/release/incubator/inlong /tmp/inlong-dist-release
+➜  ~ cd inlong-dist-release
+➜  inlong-dist-release ~ (gpg --list-sigs YOUR_NAME@apache.org && gpg --export --armor YOUR_NAME@apache.org) >> KEYS	# 追加你生成的KEY到文件KEYS中, 追加后最好检查一下是否正确
+➜  inlong-dist-release ~ svn add .	# 如果之前存在KEYS文件，则不需要
+➜  inlong-dist-release ~ svn ci -m "add gpg key for YOUR_NAME" # 接下来会要求输入用户名和密码，就用你的apache的用户名和密码。
+```
+
+### 1.6 上传GPG公钥到Github账户
+
+1. 进入 https://github.com/settings/keys ，添加GPG KEYS。
+2. 如果添加后你发现这个密钥后面写了“未经过验证” (unverified)，记得去将GPG key中用到的邮箱绑定到你的github账户上 (https://github.com/settings/emails)。
+
+## 2. 设置maven设置
+
+**如果已经设置过则跳过**
+
+在maven的配置文件~/.m2/settings.xml中，则添加下面的`<server>`项
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<settings xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.1.0 http://maven.apache.org/xsd/settings-1.1.0.xsd" xmlns="http://maven.apache.org/SETTINGS/1.1.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <servers>
+    <!-- Apache Repo Settings -->
+    <server>
+        <id>apache.snapshots.https</id>
+        <username>{user-id}</username>
+        <password>{user-pass}</password>
+    </server>
+    <server>
+        <id>apache.releases.https</id>
+        <username>{user-id}</username>
+        <password>{user-pass}</password>
+    </server>
+  </servers>
+<profiles>
+    <profile>
+      <id>apache-release</id>
+      <properties>
+        <gpg.keyname>你的KEYID</gpg.keyname><!-- Your GPG Keyname here -->
+        <!-- Use an agent: Prevents being asked for the password during the build -->
+        <gpg.useagent>true</gpg.useagent>
+        <gpg.passphrase>你的私钥的密码</gpg.passphrase>
+      </properties>
+    </profile>
+</profiles>
+</settings>
+```
+
+## 3. 编译打包
+### 3.1 准备分支
+  - 从主干分支拉取新分支作为发布分支，release-${release_version}
+
+  - 更新`CHANGES.md`
+
+  - 检查代码是否正常，包括编译成功、单元测试全部成功，RAT检查成功等等
+
+    ```shell
+    # build检查
+    $ mvn clean package -Dmaven.javadoc.skip=true
+    # RAT检查
+    $ mvn apache-rat:check
+    ```
+
+  - 更改版本号
+
+### 3.2 创建tag
+> 创建tag前，要确保代码已经检查无误，包括：编译成功、单元测试全部成功，RAT检查成功等
+
+**创建一个带签名的tag**
+```shell
+$ git_tag=${release_version}-${rc_version}
+$ git tag -s $git_tag -m "Tagging the ${release_version} first Releae Candidate (Candidates start at zero)"
+# 如果遇到错误 gpg: signing failed: secret key not available，先配置下私钥
+$ git config user.signingkey ${KEY_ID}
+```
+### 3.3 打包源码
+
+> tag创建成功后，我需要将tag源码打包成一个tar包
+
+```shell
+mkdir /tmp/apache-inlong-${release_version}-${rc_version}
+git archive --format=tar.gz --output="/tmp/apache-inlong-${release_version}-${rc_version}/apache-inlong-${release_version}-src.tar.gz" --prefix="apache-inlong-${release_version}/" $git_tag
+```
+
+### 3.4 打包二进制包
+> 编译上一步打包的源码
+
+```shell
+cd /tmp/apache-inlong-${release_version}-${rc_version} # 进入源码包目录
+tar xzvf apache-inlong-${release_version}-src.tar.gz #解压源码包
+cd apache-inlong-${release_version} # 进入源码目录
+mvn compile clean install package -DskipTests # 编译
+cp ./inlong-distribution/target/apache-inlong-${release_version}-bin.tar.gz /tmp/apache-inlong-${release_version}-${rc_version}/  # 拷贝二进制包拷到源码包目录下，方面下一步对包进行签名
+```
+
+### 3.5 对源码包/二进制包进行签名/sha512
+```shell
+for i in *.tar.gz; do echo $i; gpg --print-md SHA512 $i > $i.sha512 ; done # 计算SHA512
+for i in *.tar.gz; do echo $i; gpg --armor --output $i.asc --detach-sig $i ; done # 计算签名
+```
+
+### 3.6 检查生成的签名/sha512是否正确
+具体可以参考：[验证候选版本](how-to-verify.md)
+比如验证签名是否正确如下：
+```shell
+for i in *.tar.gz; do echo $i; gpg --verify $i.asc $i ; done
+```
+## 4. 准备Apache发布
+### 4.1 发布jar包到Apache Nexus仓库
+```shell
+cd /tmp/apache-inlong-${release_version}-${rc_version} # 进入源码包目录
+tar xzvf apache-inlong-${release_version}-src.tar.gz #解压源码包
+cd apache-inlong-${release_version}
+mvn -DskipTests deploy -Papache-release -Dmaven.javadoc.skip=true  # 开始上传
+```
+
+### 4.2 上传tag到git仓库
+
+```shell
+git push origin ${release_version}-${rc_version}
+```
+
+### 4.3 上传编译好的文件到dist
+> 这个步骤需要使用SVN, DEV分支的svn库是 https://dist.apache.org/repos/dist/dev/incubator/inlong
+
+### 4.3.1 将InLong checkout到本地目录
+```shell
+# 这个步骤可能会比较慢，会把所有版本都考下来，如果网断了，用svn cleanup删掉锁，重新执行一下，会断点续传
+svn co https://dist.apache.org/repos/dist/dev/incubator/inlong /tmp/inlong-dist-dev
+```
+
+### 4.3.2 添加public key到KEYS文件并提交到SVN仓库
+```shell
+cd /tmp/inlong-dist-dev
+mkdir ${release_version}-${rc_version} #创建版本目录
+# 将源码包和签名包拷贝到此处
+cp /tmp/apache-inlong-${release_version}-${rc_version}/*tar.gz* ${release_version}-${rc_version}/
+svn status # 检查svn状态
+svn add ${release_version}-${rc_version} # 添加到svn版本
+svn status # 检查svn状态
+svn commit -m "prepare for ${release_version} ${rc_version}"     # 提交至svn远程服务器
+```
+### 4.4 关闭Apache Staging仓库
+> 请确保所有的artifact都是ok的
+1. **先登录**http://repository.apache.org , 使用Apache账号登录
+2. 点击左侧的Staging repositories，
+3. 搜索InLong关键字，选择你最近上传的仓库
+4. 点击上方的Close按钮，这个过程会进行一系列检查
+5. 检查通过以后, 在下方的Summary标签页上出现一个连接，请保存好这个链接，需要放在接下来的投票邮件当中。
+链接应该是类似这样的: `https://repository.apache.org/content/repositories/orgapacheinlong-xxxx`
+
+WARN: 请注意点击Close可能会出现失败，请检查失败原因并处理
+
+## 5. 进入投票
+> InLong仍旧在孵化中，需要进行两次投票，
+- InLong社区投票，发邮件至：`dev@inlong.apache.org`
+- incubator社区投票，发邮件至：`general@incubator.apache.org`
+InLong毕业之后，只需要在InLong社区投票
+
+### 5.1 InLong社区投票
+
+#### 5.1.1 投票模板
+
+```html
+标题：[VOTE] Release Apache InLong ${release_version} ${rc_version}
+
+内容：
+
+Hello Apache InLong PPMC and Community,
+
+    This is a call for a vote to release Apache InLong version ${release_version}-${rc_version}.
+
+    The tag to be voted on is ${release_version}-${rc_version}:
+
+    https://github.com/apache/incubator-inlong/tree/${release_version}-${rc_version}
+
+    The release tarball, signature, and checksums can be found at:
+
+    https://dist.apache.org/repos/dist/dev/incubator/inlong/${release_version}-${rc_version}/
+
+    Maven artifacts are available in a staging repository at:
+
+    https://repository.apache.org/content/repositories/orgapacheinlong-{staging-id}
+
+    Artifacts were signed with the {YOUR_PUB_KEY} key which can be found in:
+
+    https://dist.apache.org/repos/dist/dev/incubator/inlong/KEYS
+
+    ${release_version} includes ~ ${issue_count} bug and improvement fixes done since last versions which can be found at:
+
+    https://github.com/apache/incubator-inlong/blob/${release_version}-${rc_version}/CHANGES.md
+
+    Please download, verify, and test.
+
+    The VOTE will remain open for at least 72 hours.
+
+    [ ] +1 Release this package as Apache InLong ${release_version}
+    [ ] +0
+    [ ] -1 Do not release this package because...
+
+    To learn more about apache inlong, please see
+    http://inlong.apache.org/
+
+    Checklist for reference:
+
+      [ ] Download links are valid.
+      [ ] Checksums and signatures.
+      [ ] LICENSE/NOTICE/DISCLAIMER files exist
+      [ ] No unexpected binary files
+      [ ] All source files have ASF headers
+      [ ] Can compile from source
+      [ ] All Tests Passed
+
+      More detailed checklist  please refer to:
+      https://cwiki.apache.org/confluence/display/INCUBATOR/Incubator+Release+Checklist
+
+Thanks,
+Your InLong Release Manager
+```
+
+#### 5.1.2 宣布投票结果模板
+```html
+标题：[RESULT][VOTE] Release Apache InLong ${release_version} ${rc_version}
+
+内容：
+
+Hello Apache InLong PPMC and Community,
+
+    The vote closes now as 72hr have passed. The vote PASSES with
+    xx (+1 non-binding) votes from the PPMC,
+    xx (+1 binding) vote from the IPMC,
+    xx (+1 non-binding) vote from the rest of the developer community,
+    and no further 0 or -1 votes.
+
+    The vote thread: {vote_mail_address}
+
+    I will now bring the vote to general@incubator.apache.org to get approval by the IPMC.
+    If this vote passes also, the release is accepted and will be published.
+
+Thank you for your support.
+Your InLong Release Manager
+```
+
+### 5.2 incubator社区投票
+
+#### 5.2.1 投票模板
+
+```html
+标题：[VOTE] Release Apache InLong(Incubating) ${release_version} ${rc_version}
+
+内容：
+
+Hello Incubator Community,
+
+    This is a call for a vote to release Apache InLong(Incubating) version
+    ${release_version} ${rc_version}
+
+    The Apache InLong community has voted on and approved a proposal to release
+    Apache InLong(Incubating) version ${release_version} ${rc_version}
+
+    We now kindly request the Incubator PMC members review and vote on this
+    incubator release.
+
+    InLong community vote thread:
+    • [投票链接]
+
+    Vote result thread:
+    • [投票结果链接]
+
+    The release candidate:
+    • https://dist.apache.org/repos/dist/dev/incubator/inlong/${release_version}-${rc_version}/
+
+    Git tag for the release:
+    • https://github.com/apache/incubator-inlong/tree/${release_version}-${rc_version}
+
+    Release notes:
+    • https://github.com/apache/incubator-inlong/releases/tag/${release_version}-${rc_version}
+
+    The artifacts signed with PGP key [填写你个人的KEY], corresponding to [填写你个人的邮箱], that can be found in keys file:
+    • https://dist.apache.org/repos/dist/dev/incubator/inlong/KEYS
+
+    The vote will be open for at least 72 hours or until necessary number of votes are reached.
+
+    Please vote accordingly:
+
+    [ ] +1 approve
+    [ ] +0 no opinion
+    [ ] -1 disapprove with the reason
+
+Thanks,
+On behalf of Apache InLong(Incubating) community
+
+```
+
+#### 5.2.2 宣布投票结果模板
+```html
+标题：[RESULT][VOTE] Release Apache InLong ${release_version} {rc_version}
+
+内容：
+Hi all
+
+Thanks for reviewing and voting for Apache InLong(Incubating) ${release_version} {rc_version}
+release, I am happy to announce the release voting has passed with [投票结果数]
+binding votes, no +0 or -1 votes. Binding votes are from IPMC
+
+   - xxx
+   - xxx
+   - xxx
+
+The voting thread is:
+[投票链接]
+
+Many thanks for all our mentors helping us with the release procedure, and
+all IPMC helped us to review and vote for Apache InLong(Incubating) release. I will
+be working on publishing the artifacts soon.
+
+Thanks
+On behalf of Apache InLong(Incubating) community
+```
+
+## 6. 正式发布
+
+### 6.1 合并release-${release_version}分支的改动到master分支
+### 6.2 将源码和二进制包从svn的dev目录移动到release目录
+```shell
+svn mv https://dist.apache.org/repos/dist/dev/incubator/inlong/${release_version}-${rc_version} https://dist.apache.org/repos/dist/release/incubator/inlong/${release_version} -m "Release ${release_version}"
+```
+### 6.3 确认dev和release下的包是否正确
+1. 确认[dev](https://dist.apache.org/repos/dist/dev/incubator/inlong/)下的`${release_version}-${rc_version}`已被删除
+2. 删除[release](https://dist.apache.org/repos/dist/release/incubator/inlong/)目录下上一个版本的发布包，这些包会被自动保存在[这里](https://archive.apache.org/dist/incubator/inlong/)
+```shell
+svn delete https://dist.apache.org/repos/dist/release/incubator/inlong/${last_release_version} -m "Delete ${last_release_version}"
+```
+
+### 6.4 在Apache Staging仓库发布版本
+> 请确保所有的artifact都是ok的
+1. 登录http://repository.apache.org , 使用Apache账号登录
+2. 点击左侧的Staging repositories，
+3. 搜索InLong关键字，选择你最近上传的仓库，投票邮件中指定的仓库
+4. 点击上方的`Release`按钮，这个过程会进行一系列检查
+
+**等仓库同步到其他数据源，一般需要24小时**
+
+### 6.5 更新官网链接
+
+### 6.6. 发邮件到 `dev@inlong.apache.org` 和 `general@incubator.apache.org`
+**请确保6.4中的仓库已发布成功，一般是在6.4后的24小时后发布邮件** 
+
+宣布release邮件模板：
+```html
+标题： [ANNOUNCE] Release Apache InLong(incubating) ${release_version}
+内容：
+Hi all,
+
+The Apache InLong(incubating) community is pleased to announce 
+that Apache InLong(incubating) ${release_version} has been released!
+
+Apache InLong is a one-stop data streaming platform that provides automatic, secure,
+distributed, and efficient data publishing and subscription capabilities.
+This platform helps you easily build stream-based data applications.
+
+Download Links: https://inlong.apache.org/en-us/docs/download/download.html
+
+Release Notes: https://inlong.apache.org/en-us/docs/download/${release_version}.html
+
+Website: https://inlong.apache.org/
+
+InLong Resources:
+- Issue: https://github.com/apache/incubator-inlong/issues
+- Mailing list: dev@inlong.apache.org
+
+Thanks
+On behalf of Apache InLong(Incubating) community
+```

--- a/development/how-to-subscribe.md
+++ b/development/how-to-subscribe.md
@@ -1,0 +1,39 @@
+---
+title: How to subscribe mail list
+sidebar_position: 3
+---
+
+# 订阅邮件列表
+
+<font color="#dd0000" size="4">TODO: This page needs to be translated into English. If you are interested, just do it.</font>
+
+## 1. 前言
+邮件列表是Apache社区用来沟通交流的一种形式，通常来说，Apache社区的许多事情都是由邮件列表来承载，比如：项目的提问与解答、技术讨论、事务决策、版本发布投票等等，
+订阅邮件后，你可以第一时间获取InLong社区的动态，可以与社区保持同步。
+
+#### InLong项目邮件列表
+
+|名称|描述|订阅邮件|退订邮件|邮件归档|
+|:-----|:--------|:------|:-------|:-----|
+| [dev@inlong.apache.org](mailto:dev@inlong.apache.org) | 社区活动信息 | [订阅](mailto:dev-subscribe@inlong.apache.org)   | [退订](mailto:dev-unsubscribe@inlong.apache.org)   | [归档](http://mail-archives.apache.org/mod_mbox/inlong-dev)   |
+| [commits@inlong.apache.org](mailto:commits@inlong.apache.org) | 代码库更新信息 | [订阅](mailto:commits-subscribe@inlong.apache.org)   | [退订](mailto:commits-unsubscribe@inlong.apache.org)   | [归档](http://mail-archives.apache.org/mod_mbox/inlong-commits)   |
+
+
+
+## 2. 订阅邮件列表
+**以订阅dev@inlong.apache.org邮件列表为例**
+
+具体步骤如下：
+ 1. 发送一封不包含任何内容或主题的邮件到: `dev-subscribe@inlong.apache.org`
+ 2. 等待直到收到一封主题为 `confirm subscribe to dev@inlong.apache.org` 的邮件(如果长时间未能收到，请确认该邮件是否被你的邮箱拦截，确定没有被拦截且长时间会收到回复邮件的话，返回第1步）
+ 3. 直接回复该邮件，不用修改主题和添加邮件内容。
+ 4. 等待直到收到一封主题为 `WELCOME to dev@inlong.apache.org` 的邮件。
+ 5. 收到(4)的邮件后，就说明订阅邮件成功，​若想发起讨论，直接往`dev@inlong.apache.org`发送邮件即可，所有订阅了邮件列表的人都会收到邮件。
+
+## 3. 退订邮件列表
+退订邮件列表的步骤与订阅邮件列表类似，具体步骤如下：
+1. 发送一封不包含任何内容或主题的邮件到: `dev-unsubscribe@inlong.apache.org`
+2. 等待直到收到一封主题为 `confirm unsubscribe from dev@inlong.apache.org` 的邮件
+3. 直接回复该邮件，不用修改主题和添加邮件内容
+4. 等待直到收到一封主题为 `GOODBYE from dev@inlong.apache.org`的邮件
+5. 退订成功

--- a/development/how-to-verify.md
+++ b/development/how-to-verify.md
@@ -1,0 +1,137 @@
+---
+title: How to Verify
+sidebar_position: 7
+---
+
+# 验证候选版本
+
+<font color="#dd0000" size="4">TODO: This page needs to be translated into English. If you are interested, just do it.</font>
+
+详细的检查列表请参考: [check list](https://cwiki.apache.org/confluence/display/INCUBATOR/Incubator+Release+Checklist)
+
+## 1. 下载要发布的候选版本到本地环境
+```shell
+svn co https://dist.apache.org/repos/dist/dev/incubator/inlong/${release_version}-${rc_version}/
+```
+## 2. 验证上传的版本是否合规
+> 开始验证环节，验证包含但不局限于以下内容和形式
+
+### 2.1 查看发布包是否完整
+> 上传到dist的包必须包含源码包，二进制包可选
+
+1. 是否包含源码包
+2. 是否包含源码包的签名
+3. 是否包含源码包的sha512
+4. 如果上传了二进制包，则同样检查(2)-(4)所列的内容
+
+### 2.2 检查gpg签名
+  - 导入公钥
+  ```shell
+  curl https://dist.apache.org/repos/dist/dev/incubator/inlong/KEYS > KEYS # 下载KEYS
+  gpg --import KEYS # 导入KEYS到本地
+  ```
+  - 信任公钥
+  > 信任此次版本所使用的KEY
+  ```shell
+    gpg --edit-key xxxxxxxxxx #此次版本所使用的KEY
+    gpg (GnuPG) 2.2.21; Copyright (C) 2020 Free Software Foundation, Inc.
+    This is free software: you are free to change and redistribute it.
+    There is NO WARRANTY, to the extent permitted by law.
+    
+    Secret key is available.
+    
+    sec  rsa4096/5EF3A66D57EC647A
+         created: 2020-05-19  expires: never       usage: SC  
+         trust: ultimate      validity: ultimate
+    ssb  rsa4096/17628566FEED6AF7
+         created: 2020-05-19  expires: never       usage: E   
+    [ultimate] (1). Guangxu Cheng <gxcheng@apache.org>
+    
+    gpg> trust #信任
+    sec  rsa4096/5EF3A66D57EC647A
+         created: 2020-05-19  expires: never       usage: SC  
+         trust: ultimate      validity: ultimate
+    ssb  rsa4096/17628566FEED6AF7
+         created: 2020-05-19  expires: never       usage: E   
+    [ultimate] (1). Guangxu Cheng <gxcheng@apache.org>
+    
+    Please decide how far you trust this user to correctly verify other users' keys
+    (by looking at passports, checking fingerprints from different sources, etc.)
+    
+      1 = I don't know or won't say
+      2 = I do NOT trust
+      3 = I trust marginally
+      4 = I trust fully
+      5 = I trust ultimately
+      m = back to the main menu
+    
+    Your decision? 5 #选择5
+    Do you really want to set this key to ultimate trust? (y/N) y #选择y
+                                                                 
+    sec  rsa4096/5EF3A66D57EC647A
+         created: 2020-05-19  expires: never       usage: SC  
+         trust: ultimate      validity: ultimate
+    ssb  rsa4096/17628566FEED6AF7
+         created: 2020-05-19  expires: never       usage: E   
+    [ultimate] (1). Guangxu Cheng <gxcheng@apache.org>
+    
+    gpg> 
+         
+    sec  rsa4096/5EF3A66D57EC647A
+         created: 2020-05-19  expires: never       usage: SC  
+         trust: ultimate      validity: ultimate
+    ssb  rsa4096/17628566FEED6AF7
+         created: 2020-05-19  expires: never       usage: E   
+    [ultimate] (1). Guangxu Cheng <gxcheng@apache.org>
+  ```
+  - 使用如下命令检查签名
+  ```shell
+  for i in *.tar.gz; do echo $i; gpg --verify $i.asc $i ; done
+  #或者
+  gpg --verify apache-inlong-${release_version}-src.tar.gz.asc apache-inlong-${release_version}-src.tar.gz
+  # 如果上传二进制包，则同样需要检查二进制包的签名是否正确
+  gpg --verify apache-inlong-server-${release_version}-bin.tar.gz.asc apache-inlong-server-${release_version}-bin.tar.gz
+  gpg --verify apache-inlong-client-${release_version}-bin.tar.gz.asc apache-inlong-client-${release_version}-bin.tar.gz
+```
+  - 检查结果
+  > 出现类似以下内容则说明签名正确，关键字：**`Good signature`**
+```shell
+apache-inlong-0.3.0-incubating-src.tar.gz
+gpg: Signature made Sat May 30 11:45:01 2020 CST
+gpg:                using RSA key 9B12C2228BDFF4F4CFE849445EF3A66D57EC647A
+gpg: Good signature from "Guangxu Cheng <gxcheng@apache.org>" [ultimate]gular2
+```
+
+### 2.3 检查sha512哈希
+> 本地计算sha512哈希后，验证是否与dist上的一致
+```shell
+for i in *.tar.gz; do echo $i; gpg --print-md SHA512 $i; done
+#或者
+gpg --print-md SHA512 apache-inlong-${release_version}-src.tar.gz
+# 如果上传二进制包，则同样需要检查二进制包的sha512哈希
+gpg --print-md SHA512 apache-inlong-server-${release_version}-bin.tar.gz
+gpg --print-md SHA512 apache-inlong-client-${release_version}-bin.tar.gz
+# 或者
+for i in *.tar.gz.sha512; do echo $i; sha512sum -c $i; done
+```
+
+### 2.4. 检查源码包的文件内容
+
+  解压缩`apache-inlong-${release_version}-src.tar.gz`，进行如下检查:
+
+  - DISCLAIMER文件是否存在及内容是否正确
+  - LICENSE and NOTICE文件是否存在及内容是否正确
+  - 所有文件是否带有ASF License头
+  - 源码是否能够正常编译
+  - 单测是否能够跑通
+  - ....
+
+### 2.5 检查二进制包(如果上传了二进制包)
+  解压缩`apache-inlong-client-${release_version}-src.tar.gz`和`
+  apache-inlong-server-${release_version}-src.tar.gz`，进行如下检查:
+  - DISCLAIMER文件是否存在及内容是否正确
+  - LICENSE and NOTICE文件是否存在及内容是否正确
+  - 能否正常部署成功
+  - 部署测试环境、验证生产消费能否正常运行
+  - 验证你认为可能会出问题的地方
+  - ....

--- a/development/how-to-vote-a-committer-ppmc.md
+++ b/development/how-to-vote-a-committer-ppmc.md
@@ -1,0 +1,49 @@
+---
+title: How to vote a Committer or PPMC
+sidebar_position: 5
+---
+
+
+# 成为InLong Committer 或 PPMC 的投票过程
+<font color="#dd0000" size="4">TODO: This page needs to be translated into English. If you are interested, just do it.</font>
+
+1. InLong的PPMC成员发现社区贡献者任何有价值的贡献并取得候选人本人同意后，在InLong的private邮件列表发起讨论；
+    > [DISCUSS] YYYYY as a InLong XXXXXX
+
+    邮件里要把对方的贡献，可以查看的出处说清楚，便于大家讨论分析；讨论邮件将持续至少72个小时，项目组成员，包括mentor们会针对提议邮件充分发表自己的看法；
+
+    
+2. 不管有没有分歧，在讨论邮件过后，投票发起者需要在在InLong的private邮件列表发起Committer或PPMC的选举投票；
+    > [VOTE] YYYYY as a InLong XXXXXX
+
+     投票邮件至少持续72小时，至少要3票+1通过，如果0票或者有1票-1票则投票失败；如果-1，需要把问题说清楚，便于大家理解和知晓
+
+
+3. 投票邮件结束后，由投票发起者在投票线上总结并提醒投票结束，并发投票总结邮件；
+   > [RESULTS][VOTE] YYYYY as a InLong XXXXXX
+
+
+4. 投票总结邮件发出后，投票发起者要给候选人发起邀请邮件，该邀请邮件需要候选人通过指定的邮箱回复接受或者拒绝；
+    > [Invitation] Invitation to join Apache InLong as a XXXXXX
+
+    邮件主送邀请人，抄送private@inlong.apache.org
+
+
+5. 候选人接受邀请后，如果候选人没有apache邮箱帐号，投票发起者需要协助候选人按照指引创建apache帐号；
+
+   
+6. 如果选举的是PPMC，在候选人的Apache帐号创建完成后，投票发起者还需要向IPMC的private邮件组发送知会邮件，并等待至少72小时;
+   > [NOTICE] XXXXXX for InLong PPMC
+
+   邮件主送private@incubator.apache.org，抄送private@inlong.apache.org，IPMC们会分析合规性，直到没有疑义。
+
+ 
+7. 如果以上内容都以完成，投票发起者还需要做如下2件事情：
+   7.1  向项目负责人申请添加项目组成员，开通jira及apache项目的权限帐号。     
+
+   7.2 	向dev@inlong.apache.org邮件组发通知邮件：
+      >        [ANNOUNCE] New XXXXXX: YYYYY
+
+
+到此，整个流程才算走完，候选人才正式的成为项目的Committer或者PPMC。
+


### PR DESCRIPTION
Fixes #apache/incubator-inlong#1635

where *XYZ* should be replaced by the actual issue number.

### Motivation

*Explain here the context, and why you're making that change. What is the problem you're trying to solve.*

### Modifications

*Describe the modifications you've done.*

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
