### PR TITLE
[INLONG-1656][Improve][translation] the guide of how-to-commit should be translated into English

### DIFF
--- a/development/how-to-commit.md
+++ b/development/how-to-commit.md
@@ -3,35 +3,38 @@ title: How to Commit
 sidebar_position: 2
 ---
 
-# 如何提交代码
+# How to Commit
 
-<font color="#dd0000" size="4">TODO: This page needs to be translated into English. If you are interested, just do it.</font>
+## 0. Preface
+Apache InLong uses github's Pull Request (PR) to receive contributed code. This document will introduce the process of code commit in detail.
 
-## 0. 前言
-Apache InLong使用Github的Pull Request (PR)来接收贡献的代码，本文将详细介绍提交代码的详细流程。
+- InLong code base：https://github.com/apache/incubator-inlong
 
-- InLong代码库：https://github.com/apache/incubator-inlong
+- InLong website base：https://github.com/apache/incubator-inlong-website
 
-- InLong官网库：https://github.com/apache/incubator-inlong-website
+## 1. Fork the repository
 
-## 1. Fork仓库
+Open [apache/incubator-inlong](https://github.com/apache/incubator-inlong) 's github page, clicking on the `fork` button at the top right to fork.
 
-进入 [apache/incubator-inlong](https://github.com/apache/incubator-inlong) 的Github页面 ，点击右上角按钮 `Fork` 进行 Fork。
+## 2. Configure git and commit changes
 
-## 2. 配置git和提交修改
+### 2.1 Clone your fork to your local machine
 
-### 2.1 将代码克隆到本地
 ```shell
 git clone https://github.com/<your_github_name>/incubator-inlong.git
 ```
-clone完成后，origin会默认指向github上的远程fork地址。
 
-### 2.2 将 apache/incubator-inlong 添加为本地仓库的远程分支upstream
+After clone is completed, `origin` will linked to the remote fork address on github by default.
+
+### 2.2 Add apache/incubator-inlong to local repository's remote branch upstream
+
 ```shell
 cd  incubator-inlong
 git remote add upstream https://github.com/apache/incubator-inlong.git
 ```
-### 2.3 检查远程仓库设置
+
+### 2.3 Check remote repository settings
+              
 ```shell
 git remote -v
 origin    https://github.com/<your_github_name>/incubator-inlong.git (fetch)
@@ -39,44 +42,50 @@ origin    https://github.com/<your_github_name>/incubator-inlong.git(push)
 upstream  https://github.com/apache/incubator-inlong.git (fetch)
 upstream  https://github.com/apache/incubator-inlong.git (push)
 ```
-此时会有两个仓库：origin(自己的仓库)和upstream（官方的仓库）
 
-### 2.4 获取upstream仓库代码，并更新本地master分支代码为最新
+There will be two repositories: `origin` (own repository) and `upstream` (official repository).
+
+### 2.4 Fetch code from upstream and update the local master branch code to the latest
+
 ```shell
 git fetch upstream
 git pull upstream master
 ```
-### 2.5 新建分支
-> 一般以issue id作为分支名，如：INLONG-123
+
+### 2.5 Create a new branch
+> Generally, issue id is used as the branch name, such as: INLONG-123
+
 ```shell
 git checkout -b INLONG-123
 ```
-**确保分支`INLONG-123`是基于官方master分支的最新代码**
 
-分支创建完成后即可进行代码更改。
+**Make sure that the branch `INLONG-123` is building successfully on the latest code of the official master branch**
 
-### 2.6 提交代码到远程分支
-> commit 信息的格式必须与Issue标题保持一致且以`[issue id]`开头，即：`[INLONG-123] xxx`
+After the branch is created, you can start coding.
+
+### 2.6 Commit code to remote branch
+> The format of the commit message must be consistent with the issue title and start with `[issue id]`, such as `[INLONG-123] xxx`:
 ```shell
 git commit -a -m "[INLONG-123] xxx"
 git push origin INLONG-123
 ```
-## 3. 创建PR
-### 3.1 打开自己的github仓库页面
-    `https://github.com/<your_github_name>/incubator-inlong`
-### 3.2. 切换分支
-    切换到提交的分支 `INLONG-123`
-### 3.3. 创建新PR
-    点击 `New pull request`或者`Compare & pull request`
-### 3.4. 点击`Create pull request`按钮进行创建PR
-    需要注意以下几点：
-      1. PR的标题必须以issue id开头，最好与commit信息保持一致
-      2. 可以填写部分描述信息也可以不填
-      3. 如果点击`Create pull request`后提示代码冲突，则请将`INLONG-123`分支的代码
-         与master分支同步一致后在进行提交
 
-## 4. Review代码
-创建完PR后，所有的人都可以Review代码，可能会与您讨论一些实现的细节，可能还需要你进一步修改。
-**一般该PR必须有2位以上的社区PPMC/Committer +1后，才可能正式合入官方代码库。**
+## 3. Open a Pull Request
+### 3.1 Open your github repository page
+   `https://github.com/<your_github_name>/incubator-inlong`
+### 3.2. Switch branch
+   Switch to committed branch `INLONG-123`
+### 3.3. New pull request
+   Click `New pull request` or `Compare & pull request`
+### 3.4. Click `Create pull request` button to open a PR
+   Considerations when opening a pull request:
+      1. The title of PR must start with issue id, which is better consistent with the commit message
+      2. You can fill in some description information or not
+      3. If a code conflict is prompted after clicking `Create pull request` , please synchronize the code of the `INLONG-123` branch with the master branch and commit it
 
-最后，恭喜您已经成为了InLong的官方贡献者了！
+## 4. Code Review
+After creating PR, everyone can review your code and may discuss some implementation details with you, and you may need to modify them further.
+
+**Generally, the PR can be formally merged into the code base only after more than 2 PPMC/Committer reply + 1.**
+
+Finally, congratulations on becoming an official contributor to InLong!


### PR DESCRIPTION


Fixes apache/incubator-inlong#1656

where *XYZ* should be replaced by the actual issue number.

### Motivation

*Explain here the context, and why you're making that change. What is the problem you're trying to solve.*

### Modifications

The guide of how-to-commit should be translated into English

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
