### PR TITLE
[InLong-1853][Feature][Agent] should provide docs for jmx metrics in agent 

### DIFF
--- a/docs/modules/agent/architecture.md
+++ b/docs/modules/agent/architecture.md
@@ -56,27 +56,30 @@ Users can add similar JMX (port and authentication are adjusted according to the
 
 The agent indicators are divided into the following items, and the indicators are as follows:
 
-```Shell
-AgentTaskMetric:
-runningTasks: tasks currently being executed;
-retryingTasks: Tasks that are currently being retried;
-fatalTasks: The total number of currently failed tasks;
-``
+AgentTaskMetric
 
-```Shell
-JobMetrics:
-runningJobs: the total number of currently running jobs;
-fatalJobs: the total number of currently failed jobs;
-``
+|  property   | info  |
+|  ----  | ----  |
+| runningTasks  | tasks currently being executed |
+| retryingTasks  | Tasks that are currently being retried |
+| fatalTasks  | The total number of currently failed tasks |
 
-```Shell
-PluginMetric:
-readNum: the number of reads;
-sendNum: the number of sent items;
-sendFailedNum: the number of failed sending;
-readFailedNum: the number of failed reads;
-readSuccessNum: the number of successful reads;
-sendSuccessNum: the number of successfully sent;
-``
 
+JobMetrics
+
+|  property   | info  |
+|  ----  | ----  |
+| runningJobs  | the total number of currently running jobs |
+| fatalJobs  | the total number of currently failed jobs |
+
+PluginMetric
+
+|  property   | info  |
+|  ----  | ----  |
+| readNum  | the number of reads |
+| sendNum  | the number of sent items |
+| sendFailedNum  | the number of failed sending |
+| readFailedNum  | the number of failed reads |
+| readSuccessNum  | the number of successful reads |
+| sendSuccessNum  | the number of successfully sent |
 

--- a/docs/modules/agent/architecture.md
+++ b/docs/modules/agent/architecture.md
@@ -41,6 +41,42 @@ This type of collection reads binlog and restores data by configuring mysql slav
 Need to pay attention to multi-threaded parsing when binlog is read, and multi-threaded parsing data needs to be labeled in order
 The code is based on the old version of dbsync, the main modification is to change the sending of tdbus-sender to push to agent-channel for integration
 
+##4 Monitoring indicator configuration instructions
 
+Agent provides the ability of monitoring indicators in JMX mode, and the monitoring indicators have been registered to MBeanServer
+Users can add similar JMX (port and authentication are adjusted according to the situation) to the startup parameters of the Agent to realize the collection of monitoring indicators from the remote end.
+
+```Shell
+-Dcom.sun.management.jmxremote
+-Djava.rmi.server.hostname=127.0.0.1
+-Dcom.sun.management.jmxremote.port=9999
+-Dcom.sun.management.jmxremote.authenticate=false
+-Dcom.sun.management.jmxremote.ssl=false
+``
+
+The agent indicators are divided into the following items, and the indicators are as follows:
+
+```Shell
+AgentTaskMetric:
+runningTasks: tasks currently being executed;
+retryingTasks: Tasks that are currently being retried;
+fatalTasks: The total number of currently failed tasks;
+``
+
+```Shell
+JobMetrics:
+runningJobs: the total number of currently running jobs;
+fatalJobs: the total number of currently failed jobs;
+``
+
+```Shell
+PluginMetric:
+readNum: the number of reads;
+sendNum: the number of sent items;
+sendFailedNum: the number of failed sending;
+readFailedNum: the number of failed reads;
+readSuccessNum: the number of successful reads;
+sendSuccessNum: the number of successfully sent;
+``
 
 

--- a/docs/modules/agent/architecture.md
+++ b/docs/modules/agent/architecture.md
@@ -52,7 +52,7 @@ Users can add similar JMX (port and authentication are adjusted according to the
 -Dcom.sun.management.jmxremote.port=9999
 -Dcom.sun.management.jmxremote.authenticate=false
 -Dcom.sun.management.jmxremote.ssl=false
-``
+```
 
 The agent indicators are divided into the following items, and the indicators are as follows:
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/modules/agent/architecture.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/modules/agent/architecture.md
@@ -43,6 +43,43 @@ SQL正则分解，转化成多条SQL语句
 这种方式采集属于文件采集，只不过metric采集的时候，单行的数据有格式规范
 
 
+## 4 监控指标配置说明
+
+Agent提供了JMX方式的监控指标能力，监控指标已经注册到MBeanServer
+用户可以在Agent的启动参数中增加如下类似JMX定义（端口和鉴权根据情况进行调整），实现监控指标从远端采集。
+
+```shell
+	-Dcom.sun.management.jmxremote
+	-Djava.rmi.server.hostname=127.0.0.1
+	-Dcom.sun.management.jmxremote.port=9999
+	-Dcom.sun.management.jmxremote.authenticate=false
+	-Dcom.sun.management.jmxremote.ssl=false
+```
+
+Agent指标分为以下几项, 各项的属性分别为：
+
+```shell
+AgentTaskMetric:
+runningTasks:当前正在执行的任务;
+retryingTasks:当前正在重试的任务;
+fatalTasks:当前失败的任务总数;
+```
+
+```shell
+JobMetrics:
+runningJobs:当前正在运行的job总数;
+fatalJobs:当前失败的job总数;
+```
+
+```shell
+PluginMetric:
+readNum:读取条数;
+sendNum:发送条数;
+sendFailedNum:发送失败条数;
+readFailedNum:读取失败条数;
+readSuccessNum:读取成功条数;
+sendSuccessNum:发送成功条数;
+```
 
 
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/modules/agent/architecture.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/modules/agent/architecture.md
@@ -58,28 +58,33 @@ Agent提供了JMX方式的监控指标能力，监控指标已经注册到MBeanS
 
 Agent指标分为以下几项, 各项的属性分别为：
 
-```shell
-AgentTaskMetric:
-runningTasks:当前正在执行的任务;
-retryingTasks:当前正在重试的任务;
-fatalTasks:当前失败的任务总数;
-```
 
-```shell
-JobMetrics:
-runningJobs:当前正在运行的job总数;
-fatalJobs:当前失败的job总数;
-```
+AgentTaskMetric
 
-```shell
-PluginMetric:
-readNum:读取条数;
-sendNum:发送条数;
-sendFailedNum:发送失败条数;
-readFailedNum:读取失败条数;
-readSuccessNum:读取成功条数;
-sendSuccessNum:发送成功条数;
-```
+|  属性名称   | 说明  |
+|  ----  | ----  |
+| runningTasks  | 当前正在执行的任务 |
+| retryingTasks  | 当前正在重试的任务 |
+| fatalTasks  | 当前失败的任务总数 |
+
+
+JobMetrics
+
+|  属性名称   | 说明  |
+|  ----  | ----  |
+| runningJobs  | 当前正在运行的job总数 |
+| fatalJobs  | 当前失败的job总数 |
+
+PluginMetric
+
+|  属性名称   | 说明  |
+|  ----  | ----  |
+| readNum  | 当前正在运行的job总数 |
+| sendNum  | 当前失败的job总数 |
+| sendFailedNum  | 发送失败条数 |
+| readFailedNum  | 读取失败条数 |
+| readSuccessNum  | 读取成功条数 |
+| sendSuccessNum  | 发送成功条数 |
 
 
 


### PR DESCRIPTION
Fixes [1853](https://github.com/apache/incubator-inlong/issues/1853)

### Motivation

should provide docs for jmx metrics in agent 

### Modifications

provide docs for jmx metrics in agent 

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

### Documentation

  - Does this pull request introduce a new feature? (no)
