### PR TITLE
[INLONG-1919] fix TubeMQ HTTP API xls can not download

### DIFF
--- a/docs/modules/tubemq/http_access_api.md
+++ b/docs/modules/tubemq/http_access_api.md
@@ -913,7 +913,7 @@ __Request__
 |needRefresh|no|whether it needs to refresh, default false|Boolean|
 
 More API see:
-<a href="/appendixfiles/http_access_api_definition_cn.xls"  download="http_access_api_definition_cn.xls">TubeMQ HTTP API</a>
+<a target="_blank" href="/appendixfiles/http_access_api_definition_cn.xls">TubeMQ HTTP API</a>
 
 ---
 <a href="#top">Back to top</a>

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/modules/tubemq/http_access_api.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/modules/tubemq/http_access_api.md
@@ -14,7 +14,7 @@ HTTP API是Master或者Broker对外功能暴露的接口，管控台的各项操
 
 
 由于接口众多且参数繁杂，md格式不能比较好的表达，因而以excel附件形式提供给到大家：
-<a href="/appendixfiles/http_access_api_definition_cn.xls"  download="http_access_api_definition_cn.xls">TubeMQ HTTP API</a>
+<a target="_blank" href="/appendixfiles/http_access_api_definition_cn.xls">TubeMQ HTTP API</a>
 
 ---
 <a href="#top">Back to top</a>

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-0.11.0/modules/tubemq/http_access_api.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-0.11.0/modules/tubemq/http_access_api.md
@@ -14,7 +14,7 @@ HTTP API是Master或者Broker对外功能暴露的接口，管控台的各项操
 
 
 由于接口众多且参数繁杂，md格式不能比较好的表达，因而以excel附件形式提供给到大家：
-<a href="appendixfiles/http_access_api_definition_cn.xls" target="_blank">TubeMQ HTTP API</a>
+<a target="_blank" href="/appendixfiles/http_access_api_definition_cn.xls">TubeMQ HTTP API</a>
 
 ---
 <a href="#top">Back to top</a>

--- a/versioned_docs/version-0.11.0/modules/tubemq/http_access_api.md
+++ b/versioned_docs/version-0.11.0/modules/tubemq/http_access_api.md
@@ -913,7 +913,7 @@ __Request__
 |needRefresh|no|whether it needs to refresh, default false|Boolean|
 
 More API see:
-<a href="appendixfiles/http_access_api_definition_cn.xls" target="_blank">TubeMQ HTTP API</a>
+<a target="_blank" href="/appendixfiles/http_access_api_definition_cn.xls">TubeMQ HTTP API</a>
 
 ---
 <a href="#top">Back to top</a>


### PR DESCRIPTION
Fixes #apache/incubator-inlong#1919

where *XYZ* should be replaced by the actual issue number.

### Motivation

*Explain here the context, and why you're making that change. What is the problem you're trying to solve.*

### Modifications

*Describe the modifications you've done.*

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
