### PR TITLE
[INLONG-2220] move dataproxy-sdk to inlong-sdk

### DIFF
--- a/docs/quick_start/how_to_build.md
+++ b/docs/quick_start/how_to_build.md
@@ -21,7 +21,6 @@ after compile successfully, you could find distribution file at `inlong-distribu
 ```
 inlong-agent
 inlong-dataproxy
-inlong-dataproxy-sdk
 inlong-manager-web
 inlong-sort
 inlong-tubemq-manager

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/quick_start/how_to_build.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/quick_start/how_to_build.md
@@ -21,7 +21,6 @@ $ docker run -v `pwd`:/inlong  -w /inlong maven:3.6-openjdk-8 mvn clean install 
 ```
 inlong-agent
 inlong-dataproxy
-inlong-dataproxy-sdk
 inlong-manager-web
 inlong-sort
 inlong-tubemq-manager


### PR DESCRIPTION
Fixes https://github.com/apache/incubator-inlong/issues/2220

where *XYZ* should be replaced by the actual issue number.

### Motivation

*Explain here the context, and why you're making that change. What is the problem you're trying to solve.*

### Modifications

*Describe the modifications you've done.*

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
