### PR TITLE
[INLONG-2455] unify the module name for dataproxy

### DIFF
--- a/docs/sdk/dataproxy-sdk/example.md
+++ b/docs/sdk/dataproxy-sdk/example.md
@@ -14,7 +14,7 @@ To view detailed API information [overview](./overview).
 ```
    <dependency>
            <groupId>org.apache.inlong</groupId>
-           <artifactId>inlong-dataproxy-sdk</artifactId>
+           <artifactId>dataproxy-sdk</artifactId>
            <version>${inlong_version}</version>
    </dependency>
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/sdk/dataproxy-sdk/example.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/sdk/dataproxy-sdk/example.md
@@ -14,7 +14,7 @@ Api 详情，请查看[总览](./overview)
 ```
    <dependency>
            <groupId>org.apache.inlong</groupId>
-           <artifactId>inlong-dataproxy-sdk</artifactId>
+           <artifactId>dataproxy-sdk</artifactId>
            <version>${inlong_version}</version>
    </dependency>
 ```


### PR DESCRIPTION
Fixes https://github.com/apache/incubator-inlong/issues/2455

where *XYZ* should be replaced by the actual issue number.

### Motivation

*Explain here the context, and why you're making that change. What is the problem you're trying to solve.*

### Modifications

*Describe the modifications you've done.*

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
