### PR TITLE
[INLONG-3062][Manager] Merge the data_proxy_cluster table and the third_party_cluster table

### DIFF
--- a/docs/modules/dataproxy/quick_start.md
+++ b/docs/modules/dataproxy/quick_start.md
@@ -31,27 +31,6 @@ telnet 127.0.0.1 46801
 
 After installing the DataProxy, you need to add the IP of the DataProxy service into the InLong-Manager.
 
-- Open the Swagger API page of InLong-Manager.
-
-  the address is: <http://your_manager_host:8083/api/inlong/manager/doc.html#/default/Open-Cluster-API/saveUsingPOST_4>
-
-- Click the [Debug] tab, modify the following info and copy it into the parameter box.
-  ```json
-  {
-      "name": "default_dataproxy",
-      "type": "DATA_PROXY",
-      "ip": "your_data_proxy_host",
-      "port": 46801,
-      "mqSetName": "default_set_name",
-      "inCharges": "admin",
-      "creator": "admin"
-  }
-  ```
-
-- Click the [Send] button, the above info will be saved to InLong-Manager.
-
-**Of course you can also make requests through `curl`.**
-
 - Modify the following information:
   ```html
   curl --header "Content-Type: application/json" --request POST http://your_manager_host:8083/api/inlong/manager/openapi/cluster/save --data '

--- a/docs/modules/dataproxy/quick_start.md
+++ b/docs/modules/dataproxy/quick_start.md
@@ -29,12 +29,41 @@ telnet 127.0.0.1 46801
 
 ## Add DataProxy configuration to InLong-Manager
 
-After installing the DataProxy, you need to insert the IP address of the DataProxy service is located into the backend database of InLong-Manager.
+After installing the DataProxy, you need to add the IP of the DataProxy service into the InLong-Manager.
 
-The SQL statement is:
+- Open the Swagger API page of InLong-Manager.
 
-```sql
--- address is the IP of the DataProxy service is located
-UPDATE apache_inlong_manager.data_proxy_cluster SET address="replace_by_dataproxy_ip", mq_set_name="default_set_name" WHERE name="default_dataproxy";
-```
+  the address is: <http://your_manager_host:8083/api/inlong/manager/doc.html#/default/Open-Cluster-API/saveUsingPOST_4>
 
+- Click the [Debug] tab, modify the following info and copy it into the parameter box.
+  ```json
+  {
+      "name": "default_dataproxy",
+      "type": "DATA_PROXY",
+      "ip": "your_data_proxy_host",
+      "port": 46801,
+      "mqSetName": "default_set_name",
+      "inCharges": "admin",
+      "creator": "admin"
+  }
+  ```
+
+- Click the [Send] button, the above info will be saved to InLong-Manager.
+
+**Of course you can also make requests through `curl`.**
+
+- Modify the following information:
+  ```html
+  curl --header "Content-Type: application/json" --request POST http://your_manager_host:8083/api/inlong/manager/openapi/cluster/save --data '
+  {
+     "name": "default_dataproxy",
+     "type": "DATA_PROXY",
+     "ip": "your_data_proxy_host",
+     "port": 46801,
+     "mqSetName": "default_set_name",
+     "inCharges": "admin",
+     "creator": "admin"
+  }
+  '
+  ```
+- Open your command line tool, copy the above info, and click the Enter key, the above info will be saved to InLong-Manager.

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/modules/dataproxy/quick_start.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/modules/dataproxy/quick_start.md
@@ -32,27 +32,6 @@ telnet 127.0.0.1 46801
 
 安装完 DataProxy 后，需要将 DataProxy 服务的 IP 添加到 InLong-Manager 中。
 
-- 打开 InLong-Manager 的 Swagger API 页面。
-
-  地址是：<http://your_manager_host:8083/api/inlong/manager/doc.html#/default/Open-Cluster-API/saveUsingPOST_4>
-
-- 点击 [调试] 标签, 修改下面的信息，然后拷贝到参数框中。
-  ```json
-  {
-      "name": "default_dataproxy",
-      "type": "DATA_PROXY",
-      "ip": "your_data_proxy_host",
-      "port": 46801,
-      "mqSetName": "default_set_name",
-      "inCharges": "admin",
-      "creator": "admin"
-  }
-  ```
-
-- 点击 [发送] 按钮, 上面的信息就会保存到 InLong-Manager 中。
-
-**当然你也可以通过 `curl` 发起保存请求。**
-
 - 修改下面的配置信息：
   ```html
   curl --header "Content-Type: application/json" --request POST http://your_manager_host:8083/api/inlong/manager/openapi/cluster/save --data '
@@ -67,4 +46,4 @@ telnet 127.0.0.1 46801
   }
   '
   ```
-- 打开你的命令行工具，复制上面修改后的信息，然后敲击 [回车] 键，上面的信息就会保存到 InLong-Manager 中。
+- 打开你的命令行工具，复制上面修改后的信息，然后敲击 [回车] 发起请求，上面的信息就会保存到 InLong-Manager 中。

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/modules/dataproxy/quick_start.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/modules/dataproxy/quick_start.md
@@ -30,12 +30,41 @@ telnet 127.0.0.1 46801
 
 ## 将 DataProxy 配置添加到 InLong-Manager
 
-安装完 DataProxy 后，需要将 DataProxy 所在主机的 IP 插入到 InLong-Manager 的后台数据库中。
+安装完 DataProxy 后，需要将 DataProxy 服务的 IP 添加到 InLong-Manager 中。
 
-SQL 语句为：
+- 打开 InLong-Manager 的 Swagger API 页面。
 
-```sql
--- address 为 DataProxy 服务所在主机的 IP
-UPDATE apache_inlong_manager.data_proxy_cluster SET address="replace_by_dataproxy_ip", mq_set_name="default_set_name" WHERE name="default_dataproxy";
-```
+  地址是：<http://your_manager_host:8083/api/inlong/manager/doc.html#/default/Open-Cluster-API/saveUsingPOST_4>
 
+- 点击 [调试] 标签, 修改下面的信息，然后拷贝到参数框中。
+  ```json
+  {
+      "name": "default_dataproxy",
+      "type": "DATA_PROXY",
+      "ip": "your_data_proxy_host",
+      "port": 46801,
+      "mqSetName": "default_set_name",
+      "inCharges": "admin",
+      "creator": "admin"
+  }
+  ```
+
+- 点击 [发送] 按钮, 上面的信息就会保存到 InLong-Manager 中。
+
+**当然你也可以通过 `curl` 发起保存请求。**
+
+- 修改下面的配置信息：
+  ```html
+  curl --header "Content-Type: application/json" --request POST http://your_manager_host:8083/api/inlong/manager/openapi/cluster/save --data '
+  {
+     "name": "default_dataproxy",
+     "type": "DATA_PROXY",
+     "ip": "your_data_proxy_host",
+     "port": 46801,
+     "mqSetName": "default_set_name",
+     "inCharges": "admin",
+     "creator": "admin"
+  }
+  '
+  ```
+- 打开你的命令行工具，复制上面修改后的信息，然后敲击 [回车] 键，上面的信息就会保存到 InLong-Manager 中。


### PR DESCRIPTION

Fixes [#3062](https://github.com/apache/incubator-inlong/issues/3062)

### Motivation

Merge the data_proxy_cluster table and the third_party_cluster table, and insert the data proxy cluster by OpenAPI.

### Verifying this change

- [X] Make sure that the change passes the CI checks.
