### PR TITLE
[INLONG-3067][DataProxy] Upgrading the documentation of using the default Pulsar configuration

### DIFF
--- a/docs/modules/dataproxy/overview.md
+++ b/docs/modules/dataproxy/overview.md
@@ -16,7 +16,7 @@ The overall architecture of inlong-dataproxy is based on Apache Flume. On the ba
 
 ## DataProxy Configuration
 
-DataProxy supports configurable source-channel-sink, and the configuration method is the same as the configuration file structure of flume.
+DataProxy supports configurable source-channel-sink, which is similar to flume's configuration file structure. The configuration file name is such as dataproxy-*.conf. Currently, dataproxy-pulsar.conf and dataproxy-tube.conf are supported to distinguish different message middleware types. The specific type can be specified when startup. The default (when not specified) ) using dataproxy-pulsar.conf as configuration file.
 
 - Source configuration example:
 ```shell

--- a/docs/modules/dataproxy/quick_start.md
+++ b/docs/modules/dataproxy/quick_start.md
@@ -18,7 +18,12 @@ audit.proxys=127.0.0.1:10081
 ## run
 
 ```
-sh bin/dataproxy-start.sh
+#By default, pulsar is used as the message middleware, and the dataproxy-pulsar.conf configuration file is loaded.
+bash +x bin/dataproxy-start.sh
+or
+bash +x bin/dataproxy-start.sh pulsar
+# If using Inlong TubeMQ
+# bash +x bin/dataproxy-start.sh tube
 ```
 	
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/modules/dataproxy/overview.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/modules/dataproxy/overview.md
@@ -18,7 +18,7 @@ InLong-dataProxy整体架构基于Apache Flume。inlong-dataproxy在该项目的
 
 ## DataProxy功能配置说明
 
-DataProxy支持配置化的source-channel-sink，配置方式与flume的配置文件结构相同。
+DataProxy 支持配置化的 source-channel-sink，配置方式与 flume 的配置文件结构类似。配置文件放在 dataproxy-*.conf 文件中，目前支持 dataproxy-pulsar.conf 和 dataproxy-tube.conf 两种，用于区分不同的中间件类型，具体类型可以在启动时指定，默认（未指定时）使用 dataproxy-pulsar.conf 作为配置文件
 
 - Source配置示例：
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/modules/dataproxy/quick_start.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/modules/dataproxy/quick_start.md
@@ -19,7 +19,12 @@ audit.proxys=127.0.0.1:10081
 ## 启动
 
 ```
-sh bin/dataproxy-start.sh
+#默认使用 pulsar 作为消息中间件，加载 dataproxy-pulsar.conf 配置文件
+bash +x bin/dataproxy-start.sh
+或者
+bash +x bin/dataproxy-start.sh pulsar
+# 如果使用 Inlong TubeMQ
+# bash +x bin/dataproxy-start.sh tube
 ```
 
 ## 检查


### PR DESCRIPTION
Upgrading the documentation describing the default use of pulsar configuration

Fixes [#3067](https://github.com/apache/incubator-inlong/issues/3067)