### PR TITLE
[INLONG-3225][Manager] Resolves multiple IPs when querying a DataProxy cluster

### DIFF
--- a/docs/modules/dataproxy/quick_start.md
+++ b/docs/modules/dataproxy/quick_start.md
@@ -42,7 +42,7 @@ After installing the DataProxy, you need to add the IP of the DataProxy service 
   {
      "name": "default_dataproxy",
      "type": "DATA_PROXY",
-     "ip": "your_data_proxy_host",
+     "ip": "127.0.0.1:46800,127.0.0.2",
      "port": 46801,
      "mqSetName": "default_set_name",
      "inCharges": "admin",
@@ -50,4 +50,10 @@ After installing the DataProxy, you need to add the IP of the DataProxy service 
   }
   '
   ```
+  > **[Note]**
+  >
+  > Please modify the `ip` field to the real IP (or hostname) of the DataProxy, the format is `node1:port1,node2:port2`, and separate them with `,`.
+  >
+  > If all nodes in the `ip` field have the same port, you can use `node1,node2` and modify the `port` field to the default port for those nodes.
+
 - Open your command line tool, copy the above info, and click the Enter key, the above info will be saved to InLong-Manager.

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/modules/dataproxy/quick_start.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/modules/dataproxy/quick_start.md
@@ -43,7 +43,7 @@ telnet 127.0.0.1 46801
   {
      "name": "default_dataproxy",
      "type": "DATA_PROXY",
-     "ip": "your_data_proxy_host",
+     "ip": "127.0.0.1:46800,127.0.0.2",
      "port": 46801,
      "mqSetName": "default_set_name",
      "inCharges": "admin",
@@ -51,4 +51,10 @@ telnet 127.0.0.1 46801
   }
   '
   ```
+  > **【说明】**
+  > 
+  > 请将 `ip` 字段修改为 DataProxy 服务的真实 IP（或 hostname），格式为 `node1:port1,node2:port2`，多个时用 `,` 分隔。
+  > 
+  > 如果 `ip` 字段中所有 node 的端口号都相同，可以使用 `node1,node2`，并将 `port` 字段修改为这些 node 的默认端口号。
+
 - 打开你的命令行工具，复制上面修改后的信息，然后敲击 [回车] 发起请求，上面的信息就会保存到 InLong-Manager 中。


### PR DESCRIPTION
### Title Name: [INLONG-3225][Manager] Resolves multiple IPs when querying a DataProxy cluster

Fixes [#3225](https://github.com/apache/incubator-inlong/issues/3225)

### Motivation

Support multiple IPs for the DataProxy cluster.
