### PR TITLE
[INLONG-349]Fix typo in docs

### DIFF
--- a/docs/sdk/dataproxy-sdk/example.md
+++ b/docs/sdk/dataproxy-sdk/example.md
@@ -51,7 +51,7 @@ The parameter description is as follows:
 | inLongManagerAddr      | String   | inlong admin server address                           |
 | inLongManagerPort      | String   | inlong admin server port                            |
 | netTag                 | String   | Network label, not used yet, you can pass an empty string                |
-| dataProxyGroup         | String   | dataProup group name, the name used for local configuration when the user enables local configuration         |
+| dataProxyGroup         | String   | dataProxy group name, the name used for local configuration when the user enables local configuration         |
 | isLocalVisit           | boolean  | Whether to use local configuration, true use https to access the console, false use http to request the console|
 | isReadProxyIPFromLocal | boolean  | Whether to obtain the address information of the Dataproxy server from the local configuration file, local self-test, can be set to true if the management console cannot be accessede|
 | configBasePath         | String   | The path of the local configuration file. The default is ./inlong. When isReadProxyIPFromLocal is true, the configuration file is searched from this directory|                                 |
@@ -136,7 +136,7 @@ The parameter description is as follows:
 | inLongManagerAddr      | String   | inlong admin server address                |
 | inLongManagerPort      | String   | inlong admin server port                   |
 | netTag                 | String   | Network label, not used yet, you can pass an empty string   |
-| dataProxyGroup         | String   | dataProup group name, the name used for local configuration when the user enables local configuration         |
+| dataProxyGroup         | String   | dataProxy group name, the name used for local configuration when the user enables local configuration         |
 | isLocalVisit           | boolean  | Whether to use local configuration, true use https to access the console, false use http to request the console|
 | isReadProxyIPFromLocal | boolean  | Whether to obtain the address information of the Dataproxy server from the local configuration file, local self-test, can be set to true if the management console cannot be accessed|
 | configBasePath         | String   | The path of the local configuration file. The default is ./inlong. When isReadProxyIPFromLocal is true, the configuration file is searched from this directory.|                                 |

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/sdk/dataproxy-sdk/example.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/sdk/dataproxy-sdk/example.md
@@ -50,7 +50,7 @@ Api 详情，请查看[总览](./overview)
 | inLongManagerAddr      | String   | inlong 管理台地址                             |
 | inLongManagerPort      | String   | inlong 管理台端口                             |
 | netTag                 | String   | 网络标签，暂未使用，可以传空字符串                |
-| dataProxyGroup         | String   | dataProup 组名称，用户在启用本地配置的时候，用于本地配置的名称         |
+| dataProxyGroup         | String   | dataProxy 组名称，用户在启用本地配置的时候，用于本地配置的名称         |
 | isLocalVisit           | boolean  | 是否使用本地配置， true 使用 https 访问管理台，false 使用 http 请求管理台|
 | isReadProxyIPFromLocal | boolean  | 是否从本地配置文件中获取 Dataproxy 服务器地址信息，本地自测，不能访问管理台的情况下可以配置为 true|
 | configBasePath         | String   | 本地配置文件的路径 默认 ./inlong，isReadProxyIPFromLocal 为 true 时从这个目录查找配置文件/                                 |
@@ -135,7 +135,7 @@ Api 详情，请查看[总览](./overview)
 | inLongManagerAddr      | String   | inlong 管理台地址                             |
 | inLongManagerPort      | String   | inlong 管理台端口                             |
 | netTag                 | String   | 网络标签，暂未使用，可以传空字符串                |
-| dataProxyGroup         | String   | dataProup 组名称，用户在启用本地配置的时候，用于本地配置的名称         |
+| dataProxyGroup         | String   | dataProxy 组名称，用户在启用本地配置的时候，用于本地配置的名称         |
 | isLocalVisit           | boolean  | 是否使用本地配置， true 使用 https 访问管理台，false 使用 http 请求管理台|
 | isReadProxyIPFromLocal | boolean  | 是否从本地配置文件中获取 Dataproxy 服务器地址信息，本地自测，不能访问管理台的情况下可以配置为 true|
 | configBasePath         | String   | 本地配置文件的路径 默认 ./inlong，isReadProxyIPFromLocal 为 true 时从这个目录查找配置文件/                                 |

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.0.0/sdk/dataproxy-sdk/example.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.0.0/sdk/dataproxy-sdk/example.md
@@ -50,7 +50,7 @@ Api 详情，请查看[总览](./overview)
 | inLongManagerAddr      | String   | inlong 管理台地址                             |
 | inLongManagerPort      | String   | inlong 管理台端口                             |
 | netTag                 | String   | 网络标签，暂未使用，可以传空字符串                |
-| dataProxyGroup         | String   | dataProup 组名称，用户在启用本地配置的时候，用于本地配置的名称         |
+| dataProxyGroup         | String   | dataProxy 组名称，用户在启用本地配置的时候，用于本地配置的名称         |
 | isLocalVisit           | boolean  | 是否使用本地配置， true 使用 https 访问管理台，false 使用 http 请求管理台|
 | isReadProxyIPFromLocal | boolean  | 是否从本地配置文件中获取 Dataproxy 服务器地址信息，本地自测，不能访问管理台的情况下可以配置为 true|
 | configBasePath         | String   | 本地配置文件的路径 默认 ./inlong，isReadProxyIPFromLocal 为 true 时从这个目录查找配置文件/                                 |
@@ -135,7 +135,7 @@ Api 详情，请查看[总览](./overview)
 | inLongManagerAddr      | String   | inlong 管理台地址                             |
 | inLongManagerPort      | String   | inlong 管理台端口                             |
 | netTag                 | String   | 网络标签，暂未使用，可以传空字符串                |
-| dataProxyGroup         | String   | dataProup 组名称，用户在启用本地配置的时候，用于本地配置的名称         |
+| dataProxyGroup         | String   | dataProxy 组名称，用户在启用本地配置的时候，用于本地配置的名称         |
 | isLocalVisit           | boolean  | 是否使用本地配置， true 使用 https 访问管理台，false 使用 http 请求管理台|
 | isReadProxyIPFromLocal | boolean  | 是否从本地配置文件中获取 Dataproxy 服务器地址信息，本地自测，不能访问管理台的情况下可以配置为 true|
 | configBasePath         | String   | 本地配置文件的路径 默认 ./inlong，isReadProxyIPFromLocal 为 true 时从这个目录查找配置文件/                                 |

--- a/versioned_docs/version-1.0.0/sdk/dataproxy-sdk/example.md
+++ b/versioned_docs/version-1.0.0/sdk/dataproxy-sdk/example.md
@@ -51,7 +51,7 @@ The parameter description is as follows:
 | inLongManagerAddr      | String   | inlong admin server address                           |
 | inLongManagerPort      | String   | inlong admin server port                            |
 | netTag                 | String   | Network label, not used yet, you can pass an empty string                |
-| dataProxyGroup         | String   | dataProup group name, the name used for local configuration when the user enables local configuration         |
+| dataProxyGroup         | String   | dataProxy group name, the name used for local configuration when the user enables local configuration         |
 | isLocalVisit           | boolean  | Whether to use local configuration, true use https to access the console, false use http to request the console|
 | isReadProxyIPFromLocal | boolean  | Whether to obtain the address information of the Dataproxy server from the local configuration file, local self-test, can be set to true if the management console cannot be accessede|
 | configBasePath         | String   | The path of the local configuration file. The default is ./inlong. When isReadProxyIPFromLocal is true, the configuration file is searched from this directory|                                 |
@@ -136,7 +136,7 @@ The parameter description is as follows:
 | inLongManagerAddr      | String   | inlong admin server address                |
 | inLongManagerPort      | String   | inlong admin server port                   |
 | netTag                 | String   | Network label, not used yet, you can pass an empty string   |
-| dataProxyGroup         | String   | dataProup group name, the name used for local configuration when the user enables local configuration         |
+| dataProxyGroup         | String   | dataProxy group name, the name used for local configuration when the user enables local configuration         |
 | isLocalVisit           | boolean  | Whether to use local configuration, true use https to access the console, false use http to request the console|
 | isReadProxyIPFromLocal | boolean  | Whether to obtain the address information of the Dataproxy server from the local configuration file, local self-test, can be set to true if the management console cannot be accessed|
 | configBasePath         | String   | The path of the local configuration file. The default is ./inlong. When isReadProxyIPFromLocal is true, the configuration file is searched from this directory.|                                 |


### PR DESCRIPTION
Fixes #349 

where *XYZ* should be replaced by the actual issue number.

### Motivation

### Modifications

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
